### PR TITLE
[feat/7] 커뮤니티 도메인에 사용할 JPA 엔티티 정의

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,12 @@ object VERSIONS {
     const val SWAGGER = "2.2.0"
 }
 
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
+}
+
 group = "com.numberone"
 version = "0.0.1-SNAPSHOT"
 

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/entity/Address.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/entity/Address.kt
@@ -7,12 +7,12 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "`address`")
 class Address(
-    si: String? = null,
+    si: String,
     gu: String? = null,
     dong: String? = null,
     depth: Int = 0
 ) : PrimaryKeyEntity() {
-    var si: String? = si
+    var si: String = si
         protected set
 
     var gu: String? = gu

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/entity/Address.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/entity/Address.kt
@@ -1,0 +1,26 @@
+package com.numberone.daepiro.domain.address.entity
+
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "`address`")
+class Address(
+    si: String? = null,
+    gu: String? = null,
+    dong: String? = null,
+    depth: Int = 0
+) : PrimaryKeyEntity() {
+    var si: String? = si
+        protected set
+
+    var gu: String? = gu
+        protected set
+
+    var dong: String? = dong
+        protected set
+
+    var depth: Int = depth
+        protected set
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Article.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Article.kt
@@ -1,0 +1,82 @@
+package com.numberone.daepiro.domain.community.entity
+
+import com.numberone.daepiro.domain.address.entity.Address
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import com.numberone.daepiro.domain.user.entity.UserEntity
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "article")
+class Article(
+    title: String = "",
+    body: String = "",
+    type: ArticleType = ArticleType.SNS,
+    likeCount: Int = 0,
+    viewCount: Int = 0,
+    commentCount: Int = 0,
+    reportCount: Int = 0,
+    status: ArticleStatus = ArticleStatus.ACTIVE,
+    authUser: UserEntity? = null,
+    address: Address? = null,
+) : PrimaryKeyEntity() {
+    @Column(nullable = false)
+    var title = title
+        protected set
+
+    @Column(nullable = false)
+    var body = body
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var type = type
+        protected set
+
+    @Column(nullable = false)
+    var likeCount = likeCount
+        protected set
+
+    @Column(nullable = false)
+    var viewCount = viewCount
+        protected set
+
+    @Column(nullable = false)
+    var commentCount = commentCount
+        protected set
+
+    @Column(nullable = false)
+    var reportComment = reportCount
+        protected set
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auth_user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var authUser = authUser
+        protected set
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var address = address
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status = status
+        protected set
+}
+
+enum class ArticleType {
+    SNS, INFORMATION
+}
+
+enum class ArticleStatus {
+    DELETED, ACTIVE
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Article.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Article.kt
@@ -11,7 +11,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.ForeignKey
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -37,7 +37,7 @@ class Article(
         protected set
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
     var type = type
         protected set
 
@@ -57,18 +57,18 @@ class Article(
     var reportComment = reportCount
         protected set
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "auth_user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var authUser = authUser
         protected set
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "address_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var address = address
         protected set
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
     var status = status
         protected set
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Comment.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Comment.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.ForeignKey
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -28,7 +27,7 @@ class Comment(
     var body = body
         protected set
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var authUser = authUser
         protected set
@@ -39,7 +38,7 @@ class Comment(
         protected set
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
     var documentType = documentType
         protected set
 

--- a/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Comment.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/community/entity/Comment.kt
@@ -1,0 +1,57 @@
+package com.numberone.daepiro.domain.community.entity
+
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import com.numberone.daepiro.domain.user.entity.UserEntity
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "`comment`")
+class Comment(
+    body: String = "",
+    authUser: UserEntity? = null,
+    parentComment: Comment? = null,
+    documentType: CommentDocumentType,
+    documentId: Long? = null,
+    likeCount: Int = 0
+) : PrimaryKeyEntity() {
+    @Column(nullable = false)
+    var body = body
+        protected set
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var authUser = authUser
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var parentComment = parentComment
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var documentType = documentType
+        protected set
+
+    @Column(nullable = false)
+    var documentId = documentId
+        protected set
+
+    @Column(nullable = false)
+    var likeComment = likeCount
+        protected set
+}
+
+enum class CommentDocumentType {
+    ARTICLE, DISASTER
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/file/entity/FileEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/file/entity/FileEntity.kt
@@ -19,7 +19,7 @@ class FileEntity(
         protected set
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
     var documentType = documentType
         protected set
 

--- a/src/main/kotlin/com/numberone/daepiro/domain/file/entity/FileEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/file/entity/FileEntity.kt
@@ -1,0 +1,33 @@
+package com.numberone.daepiro.domain.file.entity
+
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "`file`")
+class FileEntity(
+    path: String,
+    documentType: FileDocumentType,
+    documentId: Long
+) : PrimaryKeyEntity() {
+    @Column(nullable = false)
+    var path = path
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var documentType = documentType
+        protected set
+
+    @Column(nullable = false)
+    var documentId = documentId
+        protected set
+}
+
+enum class FileDocumentType {
+    ARTICLE, DONATION, USER_PROFILE
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserLike.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserLike.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.ForeignKey
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -20,12 +20,12 @@ class UserLike(
     documentId: Long
 ) : PrimaryKeyEntity() {
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var user = user
         protected set
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
     var documentType = documentType
         protected set
 

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserLike.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserLike.kt
@@ -1,0 +1,39 @@
+package com.numberone.daepiro.domain.user.entity
+
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "`user_like`")
+class UserLike(
+    user: UserEntity?,
+    documentType: UserLikeDocumentType,
+    documentId: Long
+) : PrimaryKeyEntity() {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var user = user
+        protected set
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var documentType = documentType
+        protected set
+
+    @Column(nullable = false)
+    var documentId = documentId
+        protected set
+}
+
+enum class UserLikeDocumentType {
+    ARTICLE, DISASTER, COMMENT
+}


### PR DESCRIPTION
## 요약
> 커뮤니티 도메인(동네생활 등)에 사용될 엔티티들을 정의했습니다.

-  #7 

커뮤니티 도메인 외에도, 현재 필요하지만 구현되지 않았던 엔티티들(UserLike, File, Address)을 추가로 구현했습니다. 이들은 커뮤니티뿐만 아니라 여러 도메인에서 재사용될 수 있습니다.

## 공유사항
1. `documentType 및 documentId 필드에 대한 설계`
    - documentType과 documentId를 이용하는 케이스에서는 JPA의 연관관계 매핑을 사용할 수 없어, 이들을 단순 컬럼으로 처리했습니다.
    - 예를 들어, documentType이 ARTICLE인 경우 documentId를 통해 article과 조인하고, documentType이 DISASTER인 경우 disasterId와 조인하는 방식입니다. 이는 엔티티가 너무 많이 생성되어 도메인이 혼잡해지는 문제점을 해결하기 위해, documentType, documentId 컬럼을 이용하여 동적 조인 방식을 어플리케이션 레벨에서 핸들링하도록 설계한 방식입니다. 단점으로는 JPA의 정적 연관관계 매핑 대신 어플리케이션에서 직접 SQL이나 JPQL을 통해 조인을 처리하게 됩니다.

2. `enum 필드 관련 처리`
    - 데이터베이스 레벨에서는 enum 필드를 varchar 타입으로 저장하도록 처리했습니다. 이를 통해 애플리케이션 레벨에서 enum 값이 변경되더라도, 데이터베이스 스키마의 변경 없이 쉽게 반영할 수 있습니다. 예를 들어 enum 값 추가/변경 시에도 DB 마이그레이션이 필요하지 않게 됩니다.
    - 이를 위해 `@Enumerated(EnumType.STRING)` 어노테이션을 사용하고, 아래와 같이 columnDefinition을 명시하여 필드를 varchar(255)로 지정했습니다.
```kotlin
    @Enumerated(EnumType.STRING)
    @Column(nullable = false, columnDefinition = "varchar(255)")
    var documentType = documentType
        protected set
``` 

> 소셜 로그인과의 충돌 가능성
UserEntity의 RegisterType 필드에도 동일한 방식으로 enum 매핑을 변경하려 했으나, 소셜 로그인 작업 패키지와 충돌할 가능성이 있어 이번 PR에서는 적용하지 않았습니다. 이 부분은 추후 소셜 로그인 작업이 완료된 후에 처리하거나, 소셜 로그인 작업 브랜치에서 반영해주시면 좋을 것 같습니다.

이번 PR에서 정의한 엔티티들의 DDL은 자동 생성된 스키마이며, 아래에 정의된 DDL 을 첨부합니다!

### Article
```sql
-- auto-generated definition
create table article
(
    id               bigint auto_increment
        primary key,
    created_at       datetime(6)  not null,
    deleted_at       datetime(6)  null,
    last_modified_at datetime(6)  not null,
    body             varchar(255) not null,
    comment_count    int          not null,
    like_count       int          not null,
    report_comment   int          not null,
    status           varchar(255) not null,
    title            varchar(255) not null,
    type             varchar(255) not null,
    view_count       int          not null,
    address_id       bigint       null,
    auth_user_id     bigint       null
);


```

### Comment
```sql
-- auto-generated definition
create table comment
(
    id                bigint auto_increment
        primary key,
    created_at        datetime(6)  not null,
    deleted_at        datetime(6)  null,
    last_modified_at  datetime(6)  not null,
    body              varchar(255) not null,
    document_id       bigint       not null,
    document_type     varchar(255) not null,
    like_comment      int          not null,
    author_user_id    bigint       null,
    parent_comment_id bigint       null
);

```

### UserLike
```sql
-- auto-generated definition
create table user_like
(
    id               bigint auto_increment
        primary key,
    created_at       datetime(6)  not null,
    deleted_at       datetime(6)  null,
    last_modified_at datetime(6)  not null,
    document_id      bigint       not null,
    document_type    varchar(255) not null,
    user_id          bigint       null
);


```

### File
```sql
-- auto-generated definition
create table file
(
    id               bigint auto_increment
        primary key,
    created_at       datetime(6)  not null,
    deleted_at       datetime(6)  null,
    last_modified_at datetime(6)  not null,
    document_id      bigint       not null,
    document_type    varchar(255) not null,
    path             varchar(255) not null
);


```

### Address
```sql
-- auto-generated definition
create table address
(
    id               bigint auto_increment
        primary key,
    created_at       datetime(6)  not null,
    deleted_at       datetime(6)  null,
    last_modified_at datetime(6)  not null,
    depth            int          not null,
    dong             varchar(255) null,
    gu               varchar(255) null,
    si               varchar(255) null
);


```