### PR TITLE
[feat/13] 수집 데이터(재난, 뉴스) 저장 api 개발

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:17
 
+ENV TZ=Asia/Seoul
 COPY build/libs/daepiro-0.0.1-SNAPSHOT.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/src/main/kotlin/com/numberone/daepiro/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SecurityConfig.kt
@@ -42,6 +42,8 @@ class SecurityConfig(
                 authorize(POST, "/v1/auth/login/**", permitAll)
                 authorize(POST, "/v1/auth/refresh", permitAll)
                 authorize(POST, "/v1/auth/admin", permitAll)
+                authorize(POST, "/v1/auth/user", permitAll)
+                authorize("/v1/datacollector/**", hasAuthority("ADMIN"))
                 authorize(anyRequest, authenticated)
             }
             addFilterBefore<ExceptionTranslationFilter>(jwtFilter)

--- a/src/main/kotlin/com/numberone/daepiro/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SecurityConfig.kt
@@ -19,6 +19,9 @@ import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.access.ExceptionTranslationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 class SecurityConfig(
@@ -47,6 +50,7 @@ class SecurityConfig(
                 authorize(anyRequest, authenticated)
             }
             addFilterBefore<ExceptionTranslationFilter>(jwtFilter)
+            cors { configurationSource = corsConfigurationSource() }
             exceptionHandling {
                 authenticationEntryPoint = authNFailHandler
                 accessDeniedHandler = authZFailHandler
@@ -54,6 +58,17 @@ class SecurityConfig(
             sessionManagement { sessionCreationPolicy = STATELESS }
         }
         return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = listOf("*")
+        configuration.allowedMethods = listOf("POST", "GET", "DELETE", "PUT")
+        configuration.allowedHeaders = listOf("*")
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
     }
 
     @Bean

--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
@@ -17,6 +18,7 @@ class SwaggerConfig {
             .components(Components().addSecuritySchemes("JWT", bearerAuth()))
             .info(configurationInfo())
             .addSecurityItem(SecurityRequirement().addList("JWT"))
+            .servers(listOf(Server().url("/")))
     }
 
     private fun configurationInfo(): Info {

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/entity/KoreaLocation.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/entity/KoreaLocation.kt
@@ -1,10 +1,13 @@
 package com.numberone.daepiro.domain.address.entity
 
+import com.numberone.daepiro.domain.disaster.entity.Disaster
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 
 @Entity
 class KoreaLocation {
@@ -20,4 +23,7 @@ class KoreaLocation {
 
     @Column(name = "eup_myeon_dong")
     var eupMyeonDong: String? = null
+
+    @OneToMany(mappedBy = "location", cascade = [CascadeType.ALL])
+    val disasters: List<Disaster> = emptyList()
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/entity/KoreaLocation.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/entity/KoreaLocation.kt
@@ -1,0 +1,23 @@
+package com.numberone.daepiro.domain.address.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class KoreaLocation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    @Column(name = "si_do")
+    var siDo: String? = null
+
+    @Column(name = "si_gun_gu")
+    var siGunGu: String? = null
+
+    @Column(name = "eup_myeon_dong")
+    var eupMyeonDong: String? = null
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/repository/KoreaLocationRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/repository/KoreaLocationRepository.kt
@@ -1,0 +1,6 @@
+package com.numberone.daepiro.domain.address.repository
+
+import com.numberone.daepiro.domain.address.entity.KoreaLocation
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface KoreaLocationRepository : JpaRepository<KoreaLocation, Long>

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/repository/KoreaLocationRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/repository/KoreaLocationRepository.kt
@@ -1,6 +1,16 @@
 package com.numberone.daepiro.domain.address.repository
 
 import com.numberone.daepiro.domain.address.entity.KoreaLocation
+import com.numberone.daepiro.domain.address.vo.AddressInfo
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface KoreaLocationRepository : JpaRepository<KoreaLocation, Long>
+interface KoreaLocationRepository : JpaRepository<KoreaLocation, Long> {
+    @Query(
+        "select k from KoreaLocation k " +
+            "where (k.siDo = :#{#addressInfo.si} or (:#{#addressInfo.si} is null and k.siDo is null)) and " +
+            "(k.siGunGu = :#{#addressInfo.gu} or (:#{#addressInfo.gu} is null and k.siGunGu is null)) and " +
+            "(k.eupMyeonDong = :#{#addressInfo.dong} or (:#{#addressInfo.dong} is null and k.eupMyeonDong is null))"
+    )
+    fun findByAddressInfo(addressInfo: AddressInfo): KoreaLocation?
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/vo/AddressInfo.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/vo/AddressInfo.kt
@@ -13,13 +13,19 @@ data class AddressInfo(
         private val suffix = arrayOf(
             listOf("시", "도"),
             listOf("시", "군", "구"),
-            listOf("읍", "면", "동")
+            listOf("읍", "면", "동", "가", "로")
         )
 
         fun from(
             fullAddress: String
         ): AddressInfo {
-            val words = fullAddress.split(" ")
+            val tempString = "TEMP_STRING"
+            val pattern = Regex("(청주시|천안시|수원시|성남시|안양시|안산시|고양시|포항시|용인시|창원시|전주시|부천시) \\S*구")
+            val matchResult = pattern.find(fullAddress)
+            val matchedString = matchResult?.value ?: ""
+            val fullAddressModified = fullAddress.replace(matchedString, tempString)
+            val words = fullAddressModified.split(" ").map { it.replace(tempString, matchedString) }
+
             var depth = 0
             var i = 0
             val address = arrayOfNulls<String>(3)

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/api/DataCollectorApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/api/DataCollectorApiV1.kt
@@ -1,0 +1,37 @@
+package com.numberone.daepiro.domain.dataCollecter.api
+
+import com.numberone.daepiro.domain.dataCollecter.dto.request.SaveDisastersRequest
+import com.numberone.daepiro.domain.dataCollecter.dto.request.SaveNewsRequest
+import com.numberone.daepiro.domain.dataCollecter.dto.response.GetLatestDisasterResponse
+import com.numberone.daepiro.domain.dataCollecter.dto.response.GetLatestNewsResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Data Collector API", description = "데이터 수집용 API")
+@RequestMapping("/v1/datacollector")
+interface DataCollectorApiV1 {
+    @GetMapping("/news/latest")
+    @Operation(summary = "최근 저장한 뉴스 정보 조회", description = "최근 저장한 뉴스 정보를 조회합니다.")
+    fun getLatestNews(): ApiResult<GetLatestNewsResponse>
+
+    @GetMapping("/disasters/latest")
+    @Operation(summary = "최근 저장한 재난 정보 조회", description = "최근 저장한 재난 정보를 조회합니다.")
+    fun getLatestDisasters(): ApiResult<GetLatestDisasterResponse>
+
+    @PostMapping("/news")
+    @Operation(summary = "뉴스 정보 저장", description = "뉴스 정보를 저장합니다.")
+    fun saveNews(
+        @RequestBody request: SaveNewsRequest
+    ): ApiResult<Unit>
+
+    @PostMapping("/disasters")
+    @Operation(summary = "재난 정보 저장", description = "재난 정보를 저장합니다.")
+    fun saveDisasters(
+        @RequestBody request: SaveDisastersRequest
+    ): ApiResult<Unit>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/controller/DataCollectorController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/controller/DataCollectorController.kt
@@ -1,0 +1,39 @@
+package com.numberone.daepiro.domain.dataCollecter.controller
+
+import com.numberone.daepiro.domain.dataCollecter.api.DataCollectorApiV1
+import com.numberone.daepiro.domain.dataCollecter.dto.request.SaveDisastersRequest
+import com.numberone.daepiro.domain.dataCollecter.dto.request.SaveNewsRequest
+import com.numberone.daepiro.domain.dataCollecter.dto.response.GetLatestDisasterResponse
+import com.numberone.daepiro.domain.dataCollecter.dto.response.GetLatestNewsResponse
+import com.numberone.daepiro.domain.dataCollecter.service.DataCollectorService
+import com.numberone.daepiro.global.dto.ApiResult
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DataCollectorController(
+    val dataCollectorService: DataCollectorService
+) : DataCollectorApiV1 {
+    override fun getLatestNews(
+    ): ApiResult<GetLatestNewsResponse> {
+        return dataCollectorService.getLatestNews()
+    }
+
+    override fun getLatestDisasters(
+    ): ApiResult<GetLatestDisasterResponse> {
+        return dataCollectorService.getLatestDisasters()
+    }
+
+    override fun saveNews(
+        request: SaveNewsRequest
+    ): ApiResult<Unit> {
+        dataCollectorService.saveNews(request)
+        return ApiResult.ok()
+    }
+
+    override fun saveDisasters(
+        request: SaveDisastersRequest
+    ): ApiResult<Unit> {
+        dataCollectorService.saveDisasters(request)
+        return ApiResult.ok()
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/controller/DataCollectorController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/controller/DataCollectorController.kt
@@ -13,13 +13,11 @@ import org.springframework.web.bind.annotation.RestController
 class DataCollectorController(
     val dataCollectorService: DataCollectorService
 ) : DataCollectorApiV1 {
-    override fun getLatestNews(
-    ): ApiResult<GetLatestNewsResponse> {
+    override fun getLatestNews(): ApiResult<GetLatestNewsResponse> {
         return dataCollectorService.getLatestNews()
     }
 
-    override fun getLatestDisasters(
-    ): ApiResult<GetLatestDisasterResponse> {
+    override fun getLatestDisasters(): ApiResult<GetLatestDisasterResponse> {
         return dataCollectorService.getLatestDisasters()
     }
 

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveDisastersRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveDisastersRequest.kt
@@ -1,0 +1,22 @@
+package com.numberone.daepiro.domain.dataCollecter.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class SaveDisastersRequest(
+    val disasters: List<DisasterRequest>
+)
+
+data class DisasterRequest(
+    @Schema(description = "재난 발생 시간", example = "2021-08-01T00:00:00")
+    val generatedAt: LocalDateTime,
+
+    @Schema(description = "재난 메시지 ID", example = "1")
+    val messageId: Long,
+
+    @Schema(description = "재난 메시지", example = "연안사고 주의보 발령. 동해안 높은 파도가 예상되므로 방파제·갯바위·해안가 등 접근 및 입수 금지, 연안 안전사고에 주의 바랍니다. [포항시]")
+    val message: String,
+
+    @Schema(description = "위치 ID", example = "2")
+    val locationId: Long,
+)

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveDisastersRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveDisastersRequest.kt
@@ -14,9 +14,15 @@ data class DisasterRequest(
     @Schema(description = "재난 메시지 ID", example = "1")
     val messageId: Long,
 
-    @Schema(description = "재난 메시지", example = "연안사고 주의보 발령. 동해안 높은 파도가 예상되므로 방파제·갯바위·해안가 등 접근 및 입수 금지, 연안 안전사고에 주의 바랍니다. [포항시]")
+    @Schema(
+        description = "재난 메시지",
+        example = "연안사고 주의보 발령. 동해안 높은 파도가 예상되므로 방파제·갯바위·해안가 등 접근 및 입수 금지, 연안 안전사고에 주의 바랍니다. [포항시]"
+    )
     val message: String,
 
-    @Schema(description = "위치 ID", example = "2")
-    val locationId: Long,
+    @Schema(description = "재난 발생 위치", example = "서울특별시 종로구")
+    val locationStr: String,
+
+    @Schema(description = "재난 종류", example = "지진")
+    val disasterType: String
 )

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveNewsRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveNewsRequest.kt
@@ -21,5 +21,5 @@ data class NewsRequest(
     val body: String,
 
     @Schema(description = "뉴스 출처", example = "출처")
-    val thumbnailUrl: String,
+    val thumbnailUrl: String?,
 )

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveNewsRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/request/SaveNewsRequest.kt
@@ -1,0 +1,25 @@
+package com.numberone.daepiro.domain.dataCollecter.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class SaveNewsRequest(
+    val news: List<NewsRequest>
+)
+
+data class NewsRequest(
+    @Schema(description = "뉴스 제목", example = "제목")
+    val title: String,
+
+    @Schema(description = "뉴스 발행 시간", example = "2021-08-01T00:00:00")
+    val publishedAt: LocalDateTime,
+
+    @Schema(description = "뉴스 부제목", example = "부제목")
+    val subtitle: String,
+
+    @Schema(description = "뉴스 본문", example = "본문")
+    val body: String,
+
+    @Schema(description = "뉴스 출처", example = "출처")
+    val thumbnailUrl: String,
+)

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/response/GetLatestDisasterResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/response/GetLatestDisasterResponse.kt
@@ -1,0 +1,18 @@
+package com.numberone.daepiro.domain.dataCollecter.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GetLatestDisasterResponse(
+    @Schema(description = "재난문자 ID", example = "1")
+    val messageId: Long
+) {
+    companion object {
+        fun from(
+            messageId: Long
+        ): GetLatestDisasterResponse {
+            return GetLatestDisasterResponse(
+                messageId = messageId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/response/GetLatestNewsResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/dto/response/GetLatestNewsResponse.kt
@@ -1,0 +1,19 @@
+package com.numberone.daepiro.domain.dataCollecter.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class GetLatestNewsResponse(
+    @Schema(description = "뉴스 발행 시간", example = "2021-08-01T00:00:00")
+    val publishedAt: LocalDateTime
+) {
+    companion object {
+        fun from(
+            publishedAt: LocalDateTime
+        ): GetLatestNewsResponse {
+            return GetLatestNewsResponse(
+                publishedAt = publishedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/entity/News.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/entity/News.kt
@@ -17,7 +17,7 @@ class News(
 
     val body: String,
 
-    val thumbnailUrl: String,
+    val thumbnailUrl: String?,
 ) : PrimaryKeyEntity() {
     companion object {
         fun of(
@@ -25,7 +25,7 @@ class News(
             publishedAt: LocalDateTime,
             subtitle: String,
             body: String,
-            thumbnailUrl: String
+            thumbnailUrl: String?
         ): News {
             return News(
                 title = title,

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/entity/News.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/entity/News.kt
@@ -1,0 +1,39 @@
+package com.numberone.daepiro.domain.dataCollecter.entity
+
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+// todo 뉴스 데이터는 추후 만들어질 게시글 스키마에 포함되고 News 스키마는 삭제 예정
+@Entity
+@Table(name = "`news`")
+class News(
+    val title: String,
+
+    val publishedAt: LocalDateTime,
+
+    val subtitle: String,
+
+    val body: String,
+
+    val thumbnailUrl: String,
+) : PrimaryKeyEntity() {
+    companion object {
+        fun of(
+            title: String,
+            publishedAt: LocalDateTime,
+            subtitle: String,
+            body: String,
+            thumbnailUrl: String
+        ): News {
+            return News(
+                title = title,
+                publishedAt = publishedAt,
+                subtitle = subtitle,
+                body = body,
+                thumbnailUrl = thumbnailUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
@@ -1,0 +1,11 @@
+package com.numberone.daepiro.domain.dataCollecter.repository
+
+import com.numberone.daepiro.domain.dataCollecter.entity.News
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+// todo 뉴스 데이터는 추후 만들어질 게시글 스키마에 포함되고 News 스키마는 삭제 예정
+interface NewsRepository : JpaRepository<News, Long> {
+    @Query("select n from News n order by n.publishedAt desc")
+    fun findLatestNews(): News?
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.Query
 // todo 뉴스 데이터는 추후 만들어질 게시글 스키마에 포함되고 News 스키마는 삭제 예정
 interface NewsRepository : JpaRepository<News, Long> {
     @Query("select n from News n order by n.publishedAt desc")
-    fun findLatestNews(): News?
+    fun findLatestNews(): List<News>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
@@ -1,0 +1,77 @@
+package com.numberone.daepiro.domain.dataCollecter.service
+
+import com.numberone.daepiro.domain.dataCollecter.dto.request.SaveDisastersRequest
+import com.numberone.daepiro.domain.dataCollecter.dto.request.SaveNewsRequest
+import com.numberone.daepiro.domain.dataCollecter.dto.response.GetLatestDisasterResponse
+import com.numberone.daepiro.domain.dataCollecter.dto.response.GetLatestNewsResponse
+import com.numberone.daepiro.domain.dataCollecter.entity.News
+import com.numberone.daepiro.domain.dataCollecter.repository.NewsRepository
+import com.numberone.daepiro.domain.disaster.entity.Disaster
+import com.numberone.daepiro.domain.disaster.repository.DisasterRepository
+import com.numberone.daepiro.global.dto.ApiResult
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class DataCollectorService(
+    private val newsRepository: NewsRepository,
+    private val disasterRepository: DisasterRepository
+) {
+    fun getLatestNews(
+    ): ApiResult<GetLatestNewsResponse> {
+        val news = newsRepository.findLatestNews()
+
+        return ApiResult.ok(
+            GetLatestNewsResponse.from(
+                publishedAt = news?.publishedAt
+                    ?: LocalDateTime.of(2000, 1, 1, 0, 0)
+            )
+        )
+    }
+
+    fun getLatestDisasters(
+    ): ApiResult<GetLatestDisasterResponse> {
+        val disaster = disasterRepository.findLatestDisaster()
+
+        return ApiResult.ok(
+            GetLatestDisasterResponse.from(
+                messageId = disaster?.messageId ?: 0
+            )
+        )
+    }
+
+    @Transactional
+    fun saveNews(
+        request: SaveNewsRequest
+    ) {
+        val news = request.news.map {
+            News.of(
+                title = it.title,
+                publishedAt = it.publishedAt,
+                subtitle = it.subtitle,
+                body = it.body,
+                thumbnailUrl = it.thumbnailUrl
+            )
+        }
+
+        newsRepository.saveAll(news)
+    }
+
+    @Transactional
+    fun saveDisasters(
+        request: SaveDisastersRequest
+    ) {
+        val disasters = request.disasters.map {
+            Disaster.of(
+                generatedAt = it.generatedAt,
+                messageId = it.messageId,
+                message = it.message,
+                locationId = it.locationId
+            )
+        }
+
+        disasterRepository.saveAll(disasters)
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
@@ -19,8 +19,7 @@ class DataCollectorService(
     private val newsRepository: NewsRepository,
     private val disasterRepository: DisasterRepository
 ) {
-    fun getLatestNews(
-    ): ApiResult<GetLatestNewsResponse> {
+    fun getLatestNews(): ApiResult<GetLatestNewsResponse> {
         val news = newsRepository.findLatestNews()
 
         return ApiResult.ok(
@@ -31,8 +30,7 @@ class DataCollectorService(
         )
     }
 
-    fun getLatestDisasters(
-    ): ApiResult<GetLatestDisasterResponse> {
+    fun getLatestDisasters(): ApiResult<GetLatestDisasterResponse> {
         val disaster = disasterRepository.findLatestDisaster()
 
         return ApiResult.ok(

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
@@ -31,7 +31,7 @@ class DataCollectorService(
     }
 
     fun getLatestDisasters(): ApiResult<GetLatestDisasterResponse> {
-        val disaster = disasterRepository.findLatestDisaster()
+        val disaster = disasterRepository.findLatestDisaster().firstOrNull()
 
         return ApiResult.ok(
             GetLatestDisasterResponse.from(

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/service/DataCollectorService.kt
@@ -20,7 +20,7 @@ class DataCollectorService(
     private val disasterRepository: DisasterRepository
 ) {
     fun getLatestNews(): ApiResult<GetLatestNewsResponse> {
-        val news = newsRepository.findLatestNews()
+        val news = newsRepository.findLatestNews().firstOrNull()
 
         return ApiResult.ok(
             GetLatestNewsResponse.from(

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/entity/Disaster.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/entity/Disaster.kt
@@ -1,7 +1,13 @@
 package com.numberone.daepiro.domain.disaster.entity
 
+import com.numberone.daepiro.domain.address.entity.KoreaLocation
 import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 
@@ -14,7 +20,13 @@ class Disaster(
 
     val message: String,
 
-    val locationId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val location: KoreaLocation,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "disaster_type_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val disasterType: DisasterType,
 
     val isDummy: Boolean
 ) : PrimaryKeyEntity() {
@@ -23,13 +35,15 @@ class Disaster(
             generatedAt: LocalDateTime,
             messageId: Long,
             message: String,
-            locationId: Long
+            location: KoreaLocation,
+            disasterType: DisasterType
         ): Disaster {
             return Disaster(
                 generatedAt = generatedAt,
                 messageId = messageId,
                 message = message,
-                locationId = locationId,
+                location = location,
+                disasterType = disasterType,
                 isDummy = false
             )
         }
@@ -38,13 +52,15 @@ class Disaster(
             generatedAt: LocalDateTime,
             messageId: Long,
             message: String,
-            locationId: Long
+            location: KoreaLocation,
+            disasterType: DisasterType
         ): Disaster {
             return Disaster(
                 generatedAt = generatedAt,
                 messageId = messageId,
                 message = message,
-                locationId = locationId,
+                location = location,
+                disasterType = disasterType,
                 isDummy = true
             )
         }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/entity/Disaster.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/entity/Disaster.kt
@@ -1,0 +1,52 @@
+package com.numberone.daepiro.domain.disaster.entity
+
+import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "`disaster`")
+class Disaster(
+    val generatedAt: LocalDateTime,
+
+    val messageId: Long,
+
+    val message: String,
+
+    val locationId: Long,
+
+    val isDummy: Boolean
+) : PrimaryKeyEntity() {
+    companion object {
+        fun of(
+            generatedAt: LocalDateTime,
+            messageId: Long,
+            message: String,
+            locationId: Long
+        ): Disaster {
+            return Disaster(
+                generatedAt = generatedAt,
+                messageId = messageId,
+                message = message,
+                locationId = locationId,
+                isDummy = false
+            )
+        }
+
+        fun ofDummy(
+            generatedAt: LocalDateTime,
+            messageId: Long,
+            message: String,
+            locationId: Long
+        ): Disaster {
+            return Disaster(
+                generatedAt = generatedAt,
+                messageId = messageId,
+                message = message,
+                locationId = locationId,
+                isDummy = true
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/entity/DisasterType.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/entity/DisasterType.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+
 @Entity
 @Table(name = "`disaster_type`")
 class DisasterType(
@@ -16,7 +17,10 @@ class DisasterType(
     val type: DisasterValue,
 
     @OneToMany(mappedBy = "disasterType", cascade = [CascadeType.ALL])
-    val userDisasterTypes: List<UserDisasterType>
+    val userDisasterTypes: List<UserDisasterType>,
+
+    @OneToMany(mappedBy = "disasterType", cascade = [CascadeType.ALL])
+    val disasters: List<Disaster>
 ) : PrimaryKeyEntity() {
     enum class DisasterValue(
         val korean: String

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/DisasterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/DisasterRepository.kt
@@ -1,0 +1,10 @@
+package com.numberone.daepiro.domain.disaster.repository
+
+import com.numberone.daepiro.domain.disaster.entity.Disaster
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface DisasterRepository : JpaRepository<Disaster, Long> {
+    @Query("select d from Disaster d order by d.messageId desc")
+    fun findLatestDisaster(): Disaster?
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/DisasterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/DisasterRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.Query
 
 interface DisasterRepository : JpaRepository<Disaster, Long> {
     @Query("select d from Disaster d order by d.messageId desc")
-    fun findLatestDisaster(): Disaster?
+    fun findLatestDisaster(): List<Disaster>
 }

--- a/src/test/kotlin/com/numberone/daepiro/domain/address/vo/AddressInfoTest.kt
+++ b/src/test/kotlin/com/numberone/daepiro/domain/address/vo/AddressInfoTest.kt
@@ -1,0 +1,28 @@
+package com.numberone.daepiro.domain.address.vo
+
+import com.numberone.daepiro.domain.address.repository.KoreaLocationRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class AddressInfoTest {
+    @Autowired
+    private lateinit var koreaLocationRepository: KoreaLocationRepository
+
+    @Test
+    fun `주소 변환 함수가 잘 작동하는 지 테스트한다`() {
+        val locationList = koreaLocationRepository.findAll()
+        for (location in locationList) {
+            var address = (location.siDo ?: "") + " " + (location.siGunGu ?: "") + " " + (location.eupMyeonDong ?: "")
+            address = address.replace("  ", " ").trim()
+            val addressInfo = AddressInfo.from(address)
+            // println("Location: $address")
+            // println("AddressInfo: $addressInfo")
+            assertEquals(location.siDo, addressInfo.si)
+            assertEquals(location.siGunGu, addressInfo.gu)
+            assertEquals(location.eupMyeonDong, addressInfo.dong)
+        }
+    }
+}


### PR DESCRIPTION
### swagger 주소
https://api.daepiro.com/swagger-ui/index.html#/Data%20Collector%20API/getLatestNews
https://api.daepiro.com/swagger-ui/index.html#/Data%20Collector%20API/getLatestDisasters
https://api.daepiro.com/swagger-ui/index.html#/Data%20Collector%20API/saveNews
https://api.daepiro.com/swagger-ui/index.html#/Data%20Collector%20API/saveDisasters

### 변경포인트
- aws lambda에서 이용할 재난, 뉴스 수집데이터 저장용 api 개발
- aws lambda에서 데이터를 수집할때 가장 최근 저장한 재난, 뉴스 데이터 정보를 주기적으로 조회해야 합니다. 때문에 이 과정에서 쿼리에 사용되는 재난의 messageId와 뉴스의 publishedAt 컬럼은 DB 상에서 인덱스를 적용해놨습니다.
- 기존에 뉴스 게시물로 커뮤니티 게시물과 하나의 Entity로 작성하기로 계획했던 것 같은데, 아직 커뮤니티 데이터 형식이 기획/디자인에서 명확화 되지 않은 것같아서 일단 임시로 뉴스Entity를 작성해놨습니다.(추후 커뮤니티 게시물 entity 만들어지면 합칠 예정)