### PR TITLE
[feat/16] swagger 에서 api 를 구분하도록 변경. (ready to use, work in progress) 

### DIFF
--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
@@ -19,6 +20,25 @@ class SwaggerConfig {
             .info(configurationInfo())
             .addSecurityItem(SecurityRequirement().addList("JWT"))
             .servers(listOf(Server().url("/")))
+    }
+
+    @Bean
+    fun readyToUseGroup(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("ready to use")
+            .pathsToMatch(
+                "/v1/auth/**",
+                "/v1/users/**",
+            )
+            .build()
+    }
+
+    @Bean
+    fun workInProgressGroup(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("work in progress")
+            .pathsToMatch("")
+            .build()
     }
 
     private fun configurationInfo(): Info {


### PR DESCRIPTION
### 작업내용

Swagger 에서 API 를 `ready to use`, `work in progress` 그룹으로 분리하여 노출되도록 하였습니다.

![image](https://github.com/user-attachments/assets/297e2620-6652-4f7a-b6f3-4aaa90b8842b)

<img width="675" alt="image" src="https://github.com/user-attachments/assets/29fc8cc4-38be-491a-8a0a-e5befeb6f242">
