### PR TITLE
[feat/15] 재난문자 내역 api 구현

### DIFF
--- a/src/main/kotlin/com/numberone/daepiro/domain/address/entity/KoreaLocation.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/entity/KoreaLocation.kt
@@ -10,20 +10,25 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 
 @Entity
-class KoreaLocation {
+class KoreaLocation(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null
+    var id: Long? = null,
 
     @Column(name = "si_do")
-    var siDo: String? = null
+    var siDo: String? = null,
 
     @Column(name = "si_gun_gu")
-    var siGunGu: String? = null
+    var siGunGu: String? = null,
 
     @Column(name = "eup_myeon_dong")
-    var eupMyeonDong: String? = null
+    var eupMyeonDong: String? = null,
 
     @OneToMany(mappedBy = "location", cascade = [CascadeType.ALL])
     val disasters: List<Disaster> = emptyList()
+) {
+    fun toAddress(): String {
+        val ret = "$siDo $siGunGu $eupMyeonDong"
+        return ret.replace(" null", "")
+    }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/repository/KoreaLocationRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/repository/KoreaLocationRepository.kt
@@ -13,4 +13,18 @@ interface KoreaLocationRepository : JpaRepository<KoreaLocation, Long> {
             "(k.eupMyeonDong = :#{#addressInfo.dong} or (:#{#addressInfo.dong} is null and k.eupMyeonDong is null))"
     )
     fun findByAddressInfo(addressInfo: AddressInfo): KoreaLocation?
+
+    @Query(
+        "select k from KoreaLocation k " +
+            "where (:#{#ai.depth} > 1 and k.siDo = :#{#ai.si} and k.siGunGu is null and k.eupMyeonDong is null) or " +
+            "(:#{#ai.depth} > 2 and k.siDo = :#{#ai.si} and k.siGunGu = :#{#ai.gu} and k.eupMyeonDong is null)"
+    )
+    fun findParentLocation(ai: AddressInfo): List<KoreaLocation>
+
+    @Query(
+        "select k from KoreaLocation k " +
+            "where (:#{#ai.depth} = 1 and k.siDo = :#{#ai.si}) or " +
+            "(:#{#ai.depth} = 2 and k.siDo = :#{#ai.si} and k.siGunGu = :#{#ai.gu})"
+    )
+    fun findChildLocation(ai: AddressInfo): List<KoreaLocation>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/repository/UserAddressRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/repository/UserAddressRepository.kt
@@ -1,6 +1,9 @@
 package com.numberone.daepiro.domain.address.repository
 
 import com.numberone.daepiro.domain.address.entity.UserAddress
+import com.numberone.daepiro.domain.user.entity.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserAddressRepository : JpaRepository<UserAddress, Long>
+interface UserAddressRepository : JpaRepository<UserAddress, Long> {
+    fun deleteAllByUser(user: UserEntity)
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/vo/AddressInfo.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/vo/AddressInfo.kt
@@ -48,5 +48,18 @@ data class AddressInfo(
                 depth = depth
             )
         }
+
+        fun from(
+            si: String,
+            gu: String?,
+            dong: String?
+        ): AddressInfo {
+            return AddressInfo(
+                si = si,
+                gu = gu,
+                dong = dong,
+                depth = if (dong != null) 3 else if (gu != null) 2 else 1
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/auth/service/AuthService.kt
@@ -17,7 +17,7 @@ import com.numberone.daepiro.global.exception.CustomErrorContext.INVALID_SOCIAL_
 import com.numberone.daepiro.global.exception.CustomErrorContext.INVALID_TOKEN
 import com.numberone.daepiro.global.exception.CustomErrorContext.NOT_FOUND_USER
 import com.numberone.daepiro.global.exception.CustomException
-import com.numberone.daepiro.global.feign.KakaoFeign
+import com.numberone.daepiro.global.feign.KakaoAuthFeign
 import com.numberone.daepiro.global.feign.NaverFeign
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional
 class AuthService(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val kakaoFeign: KakaoFeign,
+    private val kakaoAuthFeign: KakaoAuthFeign,
     private val naverFeign: NaverFeign,
     @Value("\${jwt.secret-key}") private val secretKey: String,
     @Value("\${jwt.access-token-expire}") private val accessTokenExpire: Long,
@@ -40,7 +40,7 @@ class AuthService(
     fun kakaoLogin(
         request: SocialLoginRequest
     ): ApiResult<LoginResponse> {
-        val userInfo = kakaoFeign.getUserInfo(JwtUtils.PREFIX_BEARER + request.socialToken)
+        val userInfo = kakaoAuthFeign.getUserInfo(JwtUtils.PREFIX_BEARER + request.socialToken)
             ?: throw CustomException(INVALID_SOCIAL_TOKEN)
         val socialId = userInfo.id.toString()
         val user = getOrCreateUser(socialId, SocialPlatform.KAKAO)

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/DisasterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/DisasterRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.Query
 interface DisasterRepository : JpaRepository<Disaster, Long> {
     @Query("select d from Disaster d order by d.messageId desc")
     fun findLatestDisaster(): List<Disaster>
+
+    fun findByLocationIdIn(locationIds: List<Long>): List<Disaster>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/UserDisasterTypeRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disaster/repository/UserDisasterTypeRepository.kt
@@ -1,6 +1,9 @@
 package com.numberone.daepiro.domain.disaster.repository
 
 import com.numberone.daepiro.domain.disaster.entity.UserDisasterType
+import com.numberone.daepiro.domain.user.entity.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserDisasterTypeRepository : JpaRepository<UserDisasterType, Long>
+interface UserDisasterTypeRepository : JpaRepository<UserDisasterType, Long> {
+    fun deleteAllByUser(user: UserEntity)
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/api/UserApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/api/UserApiV1.kt
@@ -3,6 +3,7 @@ package com.numberone.daepiro.domain.user.api
 import com.numberone.daepiro.domain.user.dto.request.OnboardingRequest
 import com.numberone.daepiro.domain.user.dto.request.UpdateGpsRequest
 import com.numberone.daepiro.domain.user.dto.response.CheckNicknameResponse
+import com.numberone.daepiro.domain.user.dto.response.DisasterWithRegionResponse
 import com.numberone.daepiro.domain.user.dto.response.GetUserResponse
 import com.numberone.daepiro.global.dto.ApiResult
 import io.swagger.v3.oas.annotations.Operation
@@ -40,4 +41,8 @@ interface UserApiV1 {
     fun updateGps(
         @RequestBody @Valid request: UpdateGpsRequest
     ): ApiResult<Unit>
+
+    @GetMapping("/disasters")
+    @Operation(summary = "최근 재난문자 내역 조회", description = "사용자의 최근 재난문자 내역을 조회합니다.")
+    fun getRecentDisasters(): ApiResult<List<DisasterWithRegionResponse>>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/api/UserApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/api/UserApiV1.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.user.api
 
 import com.numberone.daepiro.domain.user.dto.request.OnboardingRequest
+import com.numberone.daepiro.domain.user.dto.request.UpdateGpsRequest
 import com.numberone.daepiro.domain.user.dto.response.CheckNicknameResponse
 import com.numberone.daepiro.domain.user.dto.response.GetUserResponse
 import com.numberone.daepiro.global.dto.ApiResult
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,5 +33,11 @@ interface UserApiV1 {
     @Operation(summary = "온보딩 정보 입력", description = "사용자의 온보딩 정보를 등록합니다.")
     fun setOnboardingData(
         @RequestBody @Valid request: OnboardingRequest
+    ): ApiResult<Unit>
+
+    @PostMapping("/gps")
+    @Operation(summary = "GPS 정보 업데이트", description = "사용자의 GPS 정보를 업데이트합니다.")
+    fun updateGps(
+        @RequestBody @Valid request: UpdateGpsRequest
     ): ApiResult<Unit>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/controller/UserController.kt
@@ -4,6 +4,7 @@ import com.numberone.daepiro.domain.user.api.UserApiV1
 import com.numberone.daepiro.domain.user.dto.request.OnboardingRequest
 import com.numberone.daepiro.domain.user.dto.request.UpdateGpsRequest
 import com.numberone.daepiro.domain.user.dto.response.CheckNicknameResponse
+import com.numberone.daepiro.domain.user.dto.response.DisasterWithRegionResponse
 import com.numberone.daepiro.domain.user.dto.response.GetUserResponse
 import com.numberone.daepiro.domain.user.service.UserService
 import com.numberone.daepiro.global.dto.ApiResult
@@ -40,5 +41,9 @@ class UserController(
             request,
             SecurityContextUtils.getUserId()
         )
+    }
+
+    override fun getRecentDisasters(): ApiResult<List<DisasterWithRegionResponse>> {
+        return userService.getRecentDisasters(SecurityContextUtils.getUserId())
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/controller/UserController.kt
@@ -2,6 +2,7 @@ package com.numberone.daepiro.domain.user.controller
 
 import com.numberone.daepiro.domain.user.api.UserApiV1
 import com.numberone.daepiro.domain.user.dto.request.OnboardingRequest
+import com.numberone.daepiro.domain.user.dto.request.UpdateGpsRequest
 import com.numberone.daepiro.domain.user.dto.response.CheckNicknameResponse
 import com.numberone.daepiro.domain.user.dto.response.GetUserResponse
 import com.numberone.daepiro.domain.user.service.UserService
@@ -27,6 +28,15 @@ class UserController(
         request: OnboardingRequest
     ): ApiResult<Unit> {
         return userService.setOnboardingData(
+            request,
+            SecurityContextUtils.getUserId()
+        )
+    }
+
+    override fun updateGps(
+        request: UpdateGpsRequest
+    ): ApiResult<Unit> {
+        return userService.updateGps(
             request,
             SecurityContextUtils.getUserId()
         )

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/dto/request/UpdateGpsRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/dto/request/UpdateGpsRequest.kt
@@ -1,0 +1,18 @@
+package com.numberone.daepiro.domain.user.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Size
+
+data class UpdateGpsRequest(
+    @Schema(description = "경도", example = "126.921212")
+    @field:DecimalMin(value = "124.0", message = "대한민국 주소의 경도를 입력해주세요.")
+    @field:DecimalMax(value = "132.0", message = "대한민국 주소의 경도를 입력해주세요.")
+    val longitude: Double,
+
+    @Schema(description = "위도", example = "37.508121")
+    @field:DecimalMin(value = "33.0", message = "대한민국 주소의 위도를 입력해주세요.")
+    @field:DecimalMax(value = "43.0", message = "대한민국 주소의 위도를 입력해주세요.")
+    val latitude: Double
+)

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/dto/request/UpdateGpsRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/dto/request/UpdateGpsRequest.kt
@@ -3,7 +3,6 @@ package com.numberone.daepiro.domain.user.dto.request
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
-import jakarta.validation.constraints.Size
 
 data class UpdateGpsRequest(
     @Schema(description = "경도", example = "126.921212")

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/dto/response/DisasterResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/dto/response/DisasterResponse.kt
@@ -1,0 +1,31 @@
+package com.numberone.daepiro.domain.user.dto.response
+
+import com.numberone.daepiro.domain.disaster.entity.Disaster
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class DisasterResponse(
+    @Schema(description = "재난 종류", example = "호우")
+    val disasterType: String,
+
+    @Schema(description = "제목", example = "서울시 성북구 쌍문동 호우 발생")
+    val title: String,
+
+    @Schema(description = "내용", example = "금일 10.23. 19:39경 소촌동 855 화재 발생, 인근주민은 안전유의 및 차량우회바랍니다. 960-8222")
+    val content: String,
+
+    @Schema(description = "발생 시간", example = "2024-10-23T19:53:00")
+    val time: LocalDateTime
+) {
+    companion object {
+        fun of(disaster: Disaster): DisasterResponse {
+            val address =
+                return DisasterResponse(
+                    disasterType = disaster.disasterType.type.korean,
+                    title = "${disaster.location.toAddress()} ${disaster.disasterType.type.korean} 발생",
+                    content = disaster.message,
+                    time = disaster.generatedAt
+                )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/dto/response/DisasterWithRegionResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/dto/response/DisasterWithRegionResponse.kt
@@ -1,0 +1,20 @@
+package com.numberone.daepiro.domain.user.dto.response
+
+import com.numberone.daepiro.domain.disaster.entity.Disaster
+
+data class DisasterWithRegionResponse(
+    val region: String,
+    val disasters: List<DisasterResponse>
+) {
+    companion object {
+        fun of(
+            region: String,
+            disasters: List<Disaster>
+        ): DisasterWithRegionResponse {
+            return DisasterWithRegionResponse(
+                region = region,
+                disasters = disasters.map { DisasterResponse.of(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
@@ -1,14 +1,20 @@
 package com.numberone.daepiro.domain.user.entity
 
+import com.numberone.daepiro.domain.address.entity.KoreaLocation
 import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
 import com.numberone.daepiro.domain.user.enums.Role
 import com.numberone.daepiro.domain.user.enums.SocialPlatform
 import com.numberone.daepiro.domain.user.vo.PasswordLoginInformation
 import com.numberone.daepiro.domain.user.vo.SocialLoginInformation
+import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -27,7 +33,11 @@ class UserEntity(
 
     var nickname: String? = null,
 
-    var isCompletedOnboarding: Boolean = false
+    var isCompletedOnboarding: Boolean = false,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var location: KoreaLocation? = null,
 ) : PrimaryKeyEntity() {
     companion object {
         fun of(
@@ -54,5 +64,9 @@ class UserEntity(
 
     fun completeOnboarding() {
         isCompletedOnboarding = true
+    }
+
+    fun updateLocation(location: KoreaLocation) {
+        this.location = location
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
@@ -1,11 +1,14 @@
 package com.numberone.daepiro.domain.user.entity
 
 import com.numberone.daepiro.domain.address.entity.KoreaLocation
+import com.numberone.daepiro.domain.address.entity.UserAddress
 import com.numberone.daepiro.domain.baseentity.PrimaryKeyEntity
+import com.numberone.daepiro.domain.disaster.entity.UserDisasterType
 import com.numberone.daepiro.domain.user.enums.Role
 import com.numberone.daepiro.domain.user.enums.SocialPlatform
 import com.numberone.daepiro.domain.user.vo.PasswordLoginInformation
 import com.numberone.daepiro.domain.user.vo.SocialLoginInformation
+import jakarta.persistence.CascadeType
 import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -15,6 +18,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.ForeignKey
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
 @Entity
@@ -38,6 +42,12 @@ class UserEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var location: KoreaLocation? = null,
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
+    val userAddresses: List<UserAddress> = emptyList(),
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
+    val userDisasterTypes: List<UserDisasterType> = emptyList(),
 ) : PrimaryKeyEntity() {
     companion object {
         fun of(

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
@@ -1,8 +1,10 @@
 package com.numberone.daepiro.domain.user.service
 
 import com.numberone.daepiro.domain.address.entity.Address
+import com.numberone.daepiro.domain.address.entity.KoreaLocation
 import com.numberone.daepiro.domain.address.entity.UserAddress
 import com.numberone.daepiro.domain.address.repository.AddressRepository
+import com.numberone.daepiro.domain.address.repository.KoreaLocationRepository
 import com.numberone.daepiro.domain.address.repository.UserAddressRepository
 import com.numberone.daepiro.domain.address.vo.AddressInfo
 import com.numberone.daepiro.domain.disaster.entity.DisasterType
@@ -12,11 +14,18 @@ import com.numberone.daepiro.domain.disaster.repository.UserDisasterTypeReposito
 import com.numberone.daepiro.domain.disaster.repository.findByTypeOrThrow
 import com.numberone.daepiro.domain.user.dto.request.AddressRequest
 import com.numberone.daepiro.domain.user.dto.request.OnboardingRequest
+import com.numberone.daepiro.domain.user.dto.request.UpdateGpsRequest
 import com.numberone.daepiro.domain.user.dto.response.CheckNicknameResponse
 import com.numberone.daepiro.domain.user.entity.UserEntity
 import com.numberone.daepiro.domain.user.repository.UserRepository
 import com.numberone.daepiro.domain.user.repository.findByIdOrThrow
 import com.numberone.daepiro.global.dto.ApiResult
+import com.numberone.daepiro.global.exception.CustomErrorContext.INVALID_ADDRESS_FORMAT
+import com.numberone.daepiro.global.exception.CustomErrorContext.INVALID_COORDINATES_CONVERTER
+import com.numberone.daepiro.global.exception.CustomException
+import com.numberone.daepiro.global.feign.KakaoAuthFeign
+import com.numberone.daepiro.global.feign.KakaoLocalFeign
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -27,7 +36,10 @@ class UserService(
     private val addressRepository: AddressRepository,
     private val userAddressRepository: UserAddressRepository,
     private val userDisasterTypeRepository: UserDisasterTypeRepository,
-    private val disasterTypeRepository: DisasterTypeRepository
+    private val disasterTypeRepository: DisasterTypeRepository,
+    private val kakaoLocalFeign: KakaoLocalFeign,
+    private val koreaLocationRepository: KoreaLocationRepository,
+    @Value("\${kakao.client-id}") private val kakaoClientId: String,
 ) {
     fun checkNickname(
         nickname: String
@@ -84,5 +96,39 @@ class UserService(
             )
         }
         userAddressRepository.saveAll(userAddressList)
+    }
+
+    @Transactional
+    fun updateGps(
+        request: UpdateGpsRequest,
+        userId: Long
+    ): ApiResult<Unit> {
+        val location = getLocationFromGPS(request.longitude, request.latitude)
+        val user = userRepository.findByIdOrThrow(userId)
+
+        user.updateLocation(location)
+        return ApiResult.ok()
+    }
+
+    private fun getLocationFromGPS(
+        longitude: Double,
+        latitude: Double
+    ): KoreaLocation {
+        val kakaoAddress = kakaoLocalFeign.getAddress(
+            "KakaoAK $kakaoClientId",
+            longitude,
+            latitude
+        ) ?: throw CustomException(INVALID_COORDINATES_CONVERTER)
+        val address = kakaoAddress.documents.firstOrNull { it.regionType == "B" }
+            ?: throw CustomException(INVALID_COORDINATES_CONVERTER)
+        val location = koreaLocationRepository.findByAddressInfo(
+            AddressInfo.from(
+                address.siDo,
+                if (address.siGunGu == "") null else address.siGunGu,
+                if (address.eupMyeonDong == "") null else address.eupMyeonDong
+            )
+        ) ?: throw CustomException(INVALID_ADDRESS_FORMAT)
+
+        return location
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
@@ -24,6 +24,7 @@ enum class CustomErrorContext(
 
     // 23xx: 주소 관련 오류
     INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST, 2300, "주소 형식이 잘못되었습니다."),
+    INVALID_COORDINATES_CONVERTER(HttpStatus.INTERNAL_SERVER_ERROR, 2301, "위도, 경도를 주소로 변환하는데 실패하였습니다."),
 
     // 99xx: 공통 오류
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, 9001, "JSON 형식이 잘못되었습니다."),

--- a/src/main/kotlin/com/numberone/daepiro/global/feign/KakaoAuthFeign.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/feign/KakaoAuthFeign.kt
@@ -1,11 +1,9 @@
 package com.numberone.daepiro.global.feign
 
-import com.numberone.daepiro.global.feign.dto.KakaoLocalAddress
 import com.numberone.daepiro.global.feign.dto.KakaoUserInfo
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestParam
 
 @FeignClient(name = "kakaoAuthFeign", url = "\${kakao.base-url}")
 interface KakaoAuthFeign {

--- a/src/main/kotlin/com/numberone/daepiro/global/feign/KakaoAuthFeign.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/feign/KakaoAuthFeign.kt
@@ -1,12 +1,14 @@
 package com.numberone.daepiro.global.feign
 
+import com.numberone.daepiro.global.feign.dto.KakaoLocalAddress
 import com.numberone.daepiro.global.feign.dto.KakaoUserInfo
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 
-@FeignClient(name = "kakaoFeign", url = "\${oauth.kakao.base-url}")
-interface KakaoFeign {
-    @GetMapping(value = ["\${oauth.kakao.token-info-url}"])
+@FeignClient(name = "kakaoAuthFeign", url = "\${kakao.base-url}")
+interface KakaoAuthFeign {
+    @GetMapping(value = ["\${kakao.token-info-url}"])
     fun getUserInfo(@RequestHeader(name = "Authorization") token: String): KakaoUserInfo?
 }

--- a/src/main/kotlin/com/numberone/daepiro/global/feign/KakaoLocalFeign.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/feign/KakaoLocalFeign.kt
@@ -1,0 +1,17 @@
+package com.numberone.daepiro.global.feign
+
+import com.numberone.daepiro.global.feign.dto.KakaoLocalAddress
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "kakaoLocalFeign", url = "\${kakao.local-api-url}")
+interface KakaoLocalFeign {
+    @GetMapping
+    fun getAddress(
+        @RequestHeader(name = "Authorization") clientId: String,
+        @RequestParam("x") longitude: Double,
+        @RequestParam("y") latitude: Double
+    ): KakaoLocalAddress?
+}

--- a/src/main/kotlin/com/numberone/daepiro/global/feign/NaverFeign.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/feign/NaverFeign.kt
@@ -5,8 +5,8 @@ import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 
-@FeignClient(name = "naverFeign", url = "\${oauth.naver.base-url}")
+@FeignClient(name = "naverFeign", url = "\${naver.base-url}")
 interface NaverFeign {
-    @GetMapping(value = ["\${oauth.naver.token-info-url}"])
+    @GetMapping(value = ["\${naver.token-info-url}"])
     fun getUserInfo(@RequestHeader(name = "Authorization") token: String): NaverUserInfo?
 }

--- a/src/main/kotlin/com/numberone/daepiro/global/feign/dto/KakaoLocalAddress.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/feign/dto/KakaoLocalAddress.kt
@@ -1,0 +1,39 @@
+package com.numberone.daepiro.global.feign.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KakaoLocalAddress(
+    val meta: KakaoLocalMeta,
+    val documents: List<KakaoLocalDocument>
+)
+
+data class KakaoLocalDocument(
+    @JsonProperty("region_type")
+    val regionType: String,
+
+    val code: String,
+
+    @JsonProperty("address_name")
+    val address: String,
+
+    @JsonProperty("region_1depth_name")
+    val siDo: String,
+
+    @JsonProperty("region_2depth_name")
+    val siGunGu: String,
+
+    @JsonProperty("region_3depth_name")
+    val eupMyeonDong: String,
+
+    @JsonProperty("region_4depth_name")
+    val additionalAddress: String,
+
+    val x: Double,
+
+    val y: Double
+)
+
+data class KakaoLocalMeta(
+    @JsonProperty("total_count")
+    val totalCount: Int
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,13 +27,14 @@ jwt:
   access-token-expire: ${JWT_ACCESS_TOKEN_EXPIRE}
   refresh-token-expire: ${JWT_REFRESH_TOKEN_EXPIRE}
   admin-token-expire: ${JWT_ADMIN_TOKEN_EXPIRE}
-oauth:
-  kakao:
-    base-url: ${KAKAO_BASE_URL}
-    token-info-url: ${KAKAO_TOKEN_INFO_URL}
-  naver:
-    base-url: ${NAVER_BASE_URL}
-    token-info-url: ${NAVER_TOKEN_INFO_URL}
+kakao:
+  base-url: ${KAKAO_BASE_URL}
+  token-info-url: ${KAKAO_TOKEN_INFO_URL}
+  local-api-url: ${KAKAO_LOCAL_API_URL}
+  client-id: ${KAKAO_CLIENT_ID}
+naver:
+  base-url: ${NAVER_BASE_URL}
+  token-info-url: ${NAVER_TOKEN_INFO_URL}
 
 
 


### PR DESCRIPTION
## GPS 정보 업데이트 API 구현
https://api.daepiro.com/swagger-ui/index.html#/User%20API/updateGps
홈 화면이나 커뮤니티 동네인증 같이 사용자의 GPS 정보가 필요한 곳에서 필요에 따라 프론트에서 호출하기 위해 만들어 놨습니다. 해당 업데이트로 위도, 경도를 보내면 해당 위치의 주소를 korea_location 테이블에서 찾아 사용자의 location_id 필드에 매핑합니다.

## 최근 재난문자 내역 조회 API 구현
https://api.daepiro.com/swagger-ui/index.html#/User%20API/getRecentDisasters
<img width="340" alt="image" src="https://github.com/user-attachments/assets/bf89d043-2833-47ed-b2d1-899461ab85f2">
위 화면을 위한 재난문자 내역 API입니다. 사용자가 온보딩에서 입력한 각 장소(전체, 집, 위치1, 위치2 등)의 이름과 해당하는 재난문자 내역 리스트를 연결하여 응답하는 API 입니다.

## todo
다 만들고 생각해보니까 위 화면이나 커뮤니티 화면 같은 곳에서는 결국 무한스크롤을 적용해야 할것같네요. 무한스크롤 구현 방식도 프론트와 협의하여 통일 하는게 좋을것 같습니다!