### PR TITLE
[feat/18] FCM 연동 및 재난문자 푸시알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### FCM ###
+firebaseServiceKey.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,9 @@ dependencies {
 
     // open feign
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // fcm
+    implementation("com.google.firebase:firebase-admin:8.1.0")
 }
 
 kotlin {

--- a/src/main/kotlin/com/numberone/daepiro/config/FcmConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/FcmConfig.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
 
-
 @Configuration
 class FcmConfig(
     @Value("\${fcm.key-path}") private val keyPath: String,

--- a/src/main/kotlin/com/numberone/daepiro/config/FcmConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/FcmConfig.kt
@@ -1,0 +1,30 @@
+package com.numberone.daepiro.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+
+
+@Configuration
+class FcmConfig(
+    @Value("\${fcm.key-path}") private val keyPath: String,
+) {
+    @PostConstruct
+    fun init() {
+        try {
+            val serviceAccount = ClassPathResource(keyPath).getInputStream()
+            val options: FirebaseOptions = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build()
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/address/repository/UserAddressRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/address/repository/UserAddressRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserAddressRepository : JpaRepository<UserAddress, Long> {
     fun deleteAllByUser(user: UserEntity)
+    fun findByAddressIdIn(addressId: List<Long>): List<UserAddress>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/dto/request/OnboardingRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/dto/request/OnboardingRequest.kt
@@ -20,7 +20,10 @@ data class OnboardingRequest(
         example = "[\"지진\", \"화재\", \"태풍\"]",
     )
     @field:Size(min = 1, message = "재난 유형은 1개 이상 선택해주세요.")
-    val disasterTypes: List<String>
+    val disasterTypes: List<String>,
+
+    @Schema(description = "FCM 토큰", example = "cT9YaTTeTEeGeohmih6qWf:APA91bGoybhRF2sB6JC7mPNaqJi3XjPhwbTyy91iexup7QDB_AXxI5lug_l-4o0y9T4uYKoysdf12Wde5X01fv-dqWck1kk33d4O5TN3oz_4nzuUVa2ffE3S9ELAcZm2a308W7NGD3Sc")
+    val fcmToken: String
 )
 
 data class AddressRequest(

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
@@ -48,6 +48,8 @@ class UserEntity(
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
     val userDisasterTypes: List<UserDisasterType> = emptyList(),
+
+    var fcmToken: String? = null,
 ) : PrimaryKeyEntity() {
     companion object {
         fun of(
@@ -70,6 +72,10 @@ class UserEntity(
     ) {
         this.realname = realname
         this.nickname = nickname
+    }
+
+    fun initFcmToken(fcmToken: String) {
+        this.fcmToken = fcmToken
     }
 
     fun completeOnboarding() {

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
@@ -56,6 +56,7 @@ class UserService(
     ): ApiResult<Unit> {
         val user = userRepository.findByIdOrThrow(userId)
         user.initName(request.realname, request.nickname)
+        user.initFcmToken(request.fcmToken)
         handleOnboardingAddress(request.addresses, user)
         handleOnboardingDisasterType(request.disasterTypes, user)
         user.completeOnboarding()

--- a/src/main/kotlin/com/numberone/daepiro/global/utils/FcmUtils.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/utils/FcmUtils.kt
@@ -1,0 +1,23 @@
+package com.numberone.daepiro.global.utils
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+
+object FcmUtils {
+    fun sendFcm(tokens: List<String>, title: String, body: String) {
+        val messages = tokens.map { token ->
+            Message.builder()
+                .setNotification(
+                    Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build()
+                )
+                .setToken(token)
+                .build()
+        }
+        if (messages.isNotEmpty())
+            FirebaseMessaging.getInstance().sendAll(messages)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,8 @@ kakao:
 naver:
   base-url: ${NAVER_BASE_URL}
   token-info-url: ${NAVER_TOKEN_INFO_URL}
+fcm:
+  key-path: ${FCM_KEY_PATH}
 
 
 


### PR DESCRIPTION
feat/15, feat/20 브랜치 pr 머지 이후에 rebase 예정

그 전 까지는 커밋내역이 정리가 안되있어서 리뷰는 rebase되면 요청하겠습니다!

## 작업 내용
- fcm 연동
- 재난문자 발생시 해당 지역을 관심지역으로 설정해 놓은 사용자들에게 푸시알림 발송 (테스트X, 프론트와의 연동 이후 테스트 필요)