### PR TITLE
[fix/23] 기존 api swagger 그룹정보 반영

### DIFF
--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -29,6 +29,8 @@ class SwaggerConfig {
             .pathsToMatch(
                 "/v1/auth/**",
                 "/v1/users/**",
+                "/v1/datacollector/**",
+                "/v1/home/**"
             )
             .build()
     }


### PR DESCRIPTION
swagger를 확인해보니 기존 개발했던 api가 swagger 그룹에 포함되있지 않아 표시가 안되더라구요! 수정 완료 👍