### PR TITLE
[feat/25] 재난 콘텐츠 api 구현

### DIFF
--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -30,7 +30,8 @@ class SwaggerConfig {
                 "/v1/auth/**",
                 "/v1/users/**",
                 "/v1/datacollector/**",
-                "/v1/home/**"
+                "/v1/home/**",
+                "/v1/disastercontents/**"
             )
             .build()
     }

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.dataCollecter.repository
 
 import com.numberone.daepiro.domain.dataCollecter.entity.News
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -8,4 +9,7 @@ import org.springframework.data.jpa.repository.Query
 interface NewsRepository : JpaRepository<News, Long> {
     @Query("select n from News n order by n.publishedAt desc")
     fun findLatestNews(): List<News>
+
+    @Query("select n from News n where n.id <= :cursor order by n.publishedAt desc")
+    fun findNewsByCursor(cursor: Long, pageable: Pageable): List<News>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/dataCollecter/repository/NewsRepository.kt
@@ -12,4 +12,7 @@ interface NewsRepository : JpaRepository<News, Long> {
 
     @Query("select n from News n where n.id <= :cursor order by n.publishedAt desc")
     fun findNewsByCursor(cursor: Long, pageable: Pageable): List<News>
+
+    @Query("select n from News n where n.id <= :cursor and n.title like %:keyword% order by n.publishedAt desc")
+    fun searchNews(keyword: String, cursor: Long, pageable: Pageable): List<News>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/api/DisasterContentApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/api/DisasterContentApiV1.kt
@@ -1,6 +1,6 @@
 package com.numberone.daepiro.domain.disasterContent.api
 
-import com.numberone.daepiro.domain.disasterContent.dto.response.GetDisasterContentsResponse
+import com.numberone.daepiro.domain.disasterContent.dto.response.DisasterContentsResponse
 import com.numberone.daepiro.global.dto.ApiResult
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
@@ -24,12 +24,12 @@ interface DisasterContentApiV1 {
 
         @Schema(description = "조회할 콘텐츠 수", example = "20")
         @RequestParam size: Long
-    ): ApiResult<GetDisasterContentsResponse>
+    ): ApiResult<DisasterContentsResponse>
 
     @GetMapping("/search/{keyword}")
     @Operation(summary = "재난 콘텐츠 검색", description = "키워드를 이용해 재난 콘텐츠를 검색합니다.")
     fun searchDisasterContents(
-        @Schema(description = "검색할 키워드", example = "코로나")
+        @Schema(description = "검색할 키워드", example = "기상")
         @PathVariable keyword: String,
 
         @Schema(description = "cursor 값에는 가장 최근에 이 api를 호출했을 때 반환된 nextCursor 값을 입력해주세요. cursor 값이 없을 경우 처음 페이지를 조회합니다.", example = "991")
@@ -37,5 +37,5 @@ interface DisasterContentApiV1 {
 
         @Schema(description = "조회할 콘텐츠 수", example = "20")
         @RequestParam size: Long
-    ): ApiResult<GetDisasterContentsResponse>
+    ): ApiResult<DisasterContentsResponse>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/api/DisasterContentApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/api/DisasterContentApiV1.kt
@@ -25,4 +25,17 @@ interface DisasterContentApiV1 {
         @Schema(description = "조회할 콘텐츠 수", example = "20")
         @RequestParam size: Long
     ): ApiResult<GetDisasterContentsResponse>
+
+    @GetMapping("/search/{keyword}")
+    @Operation(summary = "재난 콘텐츠 검색", description = "키워드를 이용해 재난 콘텐츠를 검색합니다.")
+    fun searchDisasterContents(
+        @Schema(description = "검색할 키워드", example = "코로나")
+        @PathVariable keyword: String,
+
+        @Schema(description = "cursor 값에는 가장 최근에 이 api를 호출했을 때 반환된 nextCursor 값을 입력해주세요. cursor 값이 없을 경우 처음 페이지를 조회합니다.", example = "991")
+        @RequestParam(required = false) cursor: Long?,
+
+        @Schema(description = "조회할 콘텐츠 수", example = "20")
+        @RequestParam size: Long
+    ): ApiResult<GetDisasterContentsResponse>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/api/DisasterContentApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/api/DisasterContentApiV1.kt
@@ -1,0 +1,28 @@
+package com.numberone.daepiro.domain.disasterContent.api
+
+import com.numberone.daepiro.domain.disasterContent.dto.response.GetDisasterContentsResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "Disaster Content API", description = "재난 콘텐츠용 API")
+@RequestMapping("/v1/disastercontents")
+interface DisasterContentApiV1 {
+    @GetMapping("/list/{sortType}")
+    @Operation(summary = "재난 콘텐츠 목록 조회", description = "커서 기반 페이징 방식을 이용해 재난 콘텐츠 목록을 조회합니다.")
+    fun getDisasterContents(
+        @Schema(description = "정렬 방식 (latest | popular)", example = "latest")
+        @PathVariable sortType: String,
+
+        @Schema(description = "cursor 값에는 가장 최근에 이 api를 호출했을 때 반환된 nextCursor 값을 입력해주세요. cursor 값이 없을 경우 처음 페이지를 조회합니다.", example = "991")
+        @RequestParam(required = false) cursor: Long?,
+
+        @Schema(description = "조회할 콘텐츠 수", example = "20")
+        @RequestParam size: Long
+    ): ApiResult<GetDisasterContentsResponse>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/controller/DisasterContentController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/controller/DisasterContentController.kt
@@ -1,7 +1,7 @@
 package com.numberone.daepiro.domain.disasterContent.controller
 
 import com.numberone.daepiro.domain.disasterContent.api.DisasterContentApiV1
-import com.numberone.daepiro.domain.disasterContent.dto.response.GetDisasterContentsResponse
+import com.numberone.daepiro.domain.disasterContent.dto.response.DisasterContentsResponse
 import com.numberone.daepiro.domain.disasterContent.service.DisasterContentService
 import com.numberone.daepiro.global.dto.ApiResult
 import org.springframework.web.bind.annotation.RestController
@@ -14,7 +14,7 @@ class DisasterContentController(
         sortType: String,
         cursor: Long?,
         size: Long
-    ): ApiResult<GetDisasterContentsResponse> {
+    ): ApiResult<DisasterContentsResponse> {
         return disasterContentService.getDisasterContents(sortType, cursor, size)
     }
 
@@ -22,7 +22,7 @@ class DisasterContentController(
         keyword: String,
         cursor: Long?,
         size: Long
-    ): ApiResult<GetDisasterContentsResponse> {
+    ): ApiResult<DisasterContentsResponse> {
         return disasterContentService.searchDisasterContents(keyword, cursor, size)
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/controller/DisasterContentController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/controller/DisasterContentController.kt
@@ -17,4 +17,12 @@ class DisasterContentController(
     ): ApiResult<GetDisasterContentsResponse> {
         return disasterContentService.getDisasterContents(sortType, cursor, size)
     }
+
+    override fun searchDisasterContents(
+        keyword: String,
+        cursor: Long?,
+        size: Long
+    ): ApiResult<GetDisasterContentsResponse> {
+        return disasterContentService.searchDisasterContents(keyword, cursor, size)
+    }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/controller/DisasterContentController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/controller/DisasterContentController.kt
@@ -1,0 +1,20 @@
+package com.numberone.daepiro.domain.disasterContent.controller
+
+import com.numberone.daepiro.domain.disasterContent.api.DisasterContentApiV1
+import com.numberone.daepiro.domain.disasterContent.dto.response.GetDisasterContentsResponse
+import com.numberone.daepiro.domain.disasterContent.service.DisasterContentService
+import com.numberone.daepiro.global.dto.ApiResult
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DisasterContentController(
+    val disasterContentService: DisasterContentService
+) : DisasterContentApiV1 {
+    override fun getDisasterContents(
+        sortType: String,
+        cursor: Long?,
+        size: Long
+    ): ApiResult<GetDisasterContentsResponse> {
+        return disasterContentService.getDisasterContents(sortType, cursor, size)
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/dto/response/DisasterContentResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/dto/response/DisasterContentResponse.kt
@@ -1,0 +1,42 @@
+package com.numberone.daepiro.domain.disasterContent.dto.response
+
+import com.numberone.daepiro.domain.dataCollecter.entity.News
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class DisasterContentResponse(
+    @Schema(description = "제목", example = "[내일날씨] 전국 대체로 맑음…낮 기온 20도 안팎 '포근'")
+    val title: String,
+
+    @Schema(description = "썸네일 이미지 url", example = "https://img8.yna.co.kr/photo/yna/YH/2024/11/05/PYH2024110509530001300_T2.jpg")
+    val thumbnailUrl: String?,
+
+    @Schema(description = "기사 url", example = "https://www.yna.co.kr/view/AKR20241110003300004?section=safe/news")
+    val bodyUrl: String,
+
+    @Schema(description = "출처", example = "연합뉴스")
+    val source: String,
+
+    @Schema(description = "게시일", example = "2021-08-01T00:00:00")
+    val publishedAt: LocalDateTime,
+
+    @Schema(description = "조회수", example = "10")
+    val viewCount: Int,
+
+    @Schema(description = "좋아요 수", example = "10")
+    val likeCount: Int,
+) {
+    companion object {
+        fun of(news: News): DisasterContentResponse {
+            return DisasterContentResponse(
+                title = news.title,
+                thumbnailUrl = news.thumbnailUrl,
+                bodyUrl = news.body,
+                source = "연합뉴스", // todo(추후 기획에서 뉴스 이외에 콘텐츠가 추가 되면 변경)
+                publishedAt = news.publishedAt,
+                viewCount = 10, // todo(조회수와 좋아요수는 article 도메인이 만들어진 후에 반영)
+                likeCount = 5,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/dto/response/DisasterContentsResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/dto/response/DisasterContentsResponse.kt
@@ -3,7 +3,7 @@ package com.numberone.daepiro.domain.disasterContent.dto.response
 import com.numberone.daepiro.domain.dataCollecter.entity.News
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class GetDisasterContentsResponse(
+data class DisasterContentsResponse(
     @Schema(description = "다음 페이지를 조회하기 위한 cursor 값", example = "971")
     val nextCursor: Long?,
 
@@ -12,14 +12,14 @@ data class GetDisasterContentsResponse(
     companion object {
         fun of(
             news: List<News>
-        ): GetDisasterContentsResponse {
+        ): DisasterContentsResponse {
             if (news.isEmpty()) {
-                return GetDisasterContentsResponse(
+                return DisasterContentsResponse(
                     nextCursor = null,
                     contents = emptyList()
                 )
             }
-            return GetDisasterContentsResponse(
+            return DisasterContentsResponse(
                 nextCursor = news.last().id!! - 1,
                 contents = news.map { DisasterContentResponse.of(it) }
             )

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/dto/response/GetDisasterContentsResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/dto/response/GetDisasterContentsResponse.kt
@@ -1,0 +1,28 @@
+package com.numberone.daepiro.domain.disasterContent.dto.response
+
+import com.numberone.daepiro.domain.dataCollecter.entity.News
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GetDisasterContentsResponse(
+    @Schema(description = "다음 페이지를 조회하기 위한 cursor 값", example = "971")
+    val nextCursor: Long?,
+
+    val contents: List<DisasterContentResponse>
+) {
+    companion object {
+        fun of(
+            news: List<News>
+        ): GetDisasterContentsResponse {
+            if (news.isEmpty()) {
+                return GetDisasterContentsResponse(
+                    nextCursor = null,
+                    contents = emptyList()
+                )
+            }
+            return GetDisasterContentsResponse(
+                nextCursor = news.last().id!! - 1,
+                contents = news.map { DisasterContentResponse.of(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/service/DisasterContentService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/service/DisasterContentService.kt
@@ -1,7 +1,7 @@
 package com.numberone.daepiro.domain.disasterContent.service
 
 import com.numberone.daepiro.domain.dataCollecter.repository.NewsRepository
-import com.numberone.daepiro.domain.disasterContent.dto.response.GetDisasterContentsResponse
+import com.numberone.daepiro.domain.disasterContent.dto.response.DisasterContentsResponse
 import com.numberone.daepiro.global.dto.ApiResult
 import com.numberone.daepiro.global.exception.CustomErrorContext.INVALID_DISASTER_CONTENT_SORT_TYPE
 import com.numberone.daepiro.global.exception.CustomException
@@ -18,11 +18,11 @@ class DisasterContentService(
         sortType: String,
         cursor: Long?,
         size: Long
-    ): ApiResult<GetDisasterContentsResponse> {
+    ): ApiResult<DisasterContentsResponse> {
         val pageable = PageRequest.of(0, size.toInt())
         val currentCursor = cursor
             ?: newsRepository.findLatestNews().firstOrNull()?.id
-            ?: return ApiResult.ok(GetDisasterContentsResponse.of(emptyList()))
+            ?: return ApiResult.ok(DisasterContentsResponse.of(emptyList()))
 
         val newsList = when (sortType) {
             "latest" -> {
@@ -39,21 +39,21 @@ class DisasterContentService(
             }
         }
 
-        return ApiResult.ok(GetDisasterContentsResponse.of(newsList))
+        return ApiResult.ok(DisasterContentsResponse.of(newsList))
     }
 
     fun searchDisasterContents(
         keyword: String,
         cursor: Long?,
         size: Long
-    ): ApiResult<GetDisasterContentsResponse> {
+    ): ApiResult<DisasterContentsResponse> {
         val pageable = PageRequest.of(0, size.toInt())
         val currentCursor = cursor
             ?: newsRepository.findLatestNews().firstOrNull()?.id
-            ?: return ApiResult.ok(GetDisasterContentsResponse.of(emptyList()))
+            ?: return ApiResult.ok(DisasterContentsResponse.of(emptyList()))
 
         val newsList = newsRepository.searchNews(keyword, currentCursor, pageable)
 
-        return ApiResult.ok(GetDisasterContentsResponse.of(newsList))
+        return ApiResult.ok(DisasterContentsResponse.of(newsList))
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/service/DisasterContentService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/service/DisasterContentService.kt
@@ -1,0 +1,44 @@
+package com.numberone.daepiro.domain.disasterContent.service
+
+import com.numberone.daepiro.domain.dataCollecter.repository.NewsRepository
+import com.numberone.daepiro.domain.disasterContent.dto.response.GetDisasterContentsResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import com.numberone.daepiro.global.exception.CustomErrorContext.INVALID_DISASTER_CONTENT_SORT_TYPE
+import com.numberone.daepiro.global.exception.CustomException
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class DisasterContentService(
+    val newsRepository: NewsRepository
+) {
+    fun getDisasterContents(
+        sortType: String,
+        cursor: Long?,
+        size: Long
+    ): ApiResult<GetDisasterContentsResponse> {
+        val pageable = PageRequest.of(0, size.toInt())
+        val currentCursor = cursor
+            ?: newsRepository.findLatestNews().firstOrNull()?.id
+            ?: return ApiResult.ok(GetDisasterContentsResponse.of(emptyList()))
+
+        val newsList = when (sortType) {
+            "latest" -> {
+                newsRepository.findNewsByCursor(currentCursor, pageable)
+            }
+
+            "popular" -> {
+                // todo(좋아요 도메인이 만들어진 후에는 sortType이 popular일 때 좋아요 순으로 정렬)
+                newsRepository.findNewsByCursor(currentCursor, pageable)
+            }
+
+            else -> {
+                throw CustomException(INVALID_DISASTER_CONTENT_SORT_TYPE)
+            }
+        }
+
+        return ApiResult.ok(GetDisasterContentsResponse.of(newsList))
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/service/DisasterContentService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterContent/service/DisasterContentService.kt
@@ -41,4 +41,19 @@ class DisasterContentService(
 
         return ApiResult.ok(GetDisasterContentsResponse.of(newsList))
     }
+
+    fun searchDisasterContents(
+        keyword: String,
+        cursor: Long?,
+        size: Long
+    ): ApiResult<GetDisasterContentsResponse> {
+        val pageable = PageRequest.of(0, size.toInt())
+        val currentCursor = cursor
+            ?: newsRepository.findLatestNews().firstOrNull()?.id
+            ?: return ApiResult.ok(GetDisasterContentsResponse.of(emptyList()))
+
+        val newsList = newsRepository.searchNews(keyword, currentCursor, pageable)
+
+        return ApiResult.ok(GetDisasterContentsResponse.of(newsList))
+    }
 }

--- a/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
@@ -27,6 +27,9 @@ enum class CustomErrorContext(
     INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST, 2300, "주소 형식이 잘못되었습니다."),
     INVALID_COORDINATES_CONVERTER(HttpStatus.INTERNAL_SERVER_ERROR, 2301, "위도, 경도를 주소로 변환하는데 실패하였습니다."),
 
+    // 24xx: 재난콘텐츠 관련 오류
+    INVALID_DISASTER_CONTENT_SORT_TYPE(HttpStatus.BAD_REQUEST, 2400, "재난 콘텐츠 정렬 형식이 잘못되었습니다."),
+
     // 99xx: 공통 오류
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, 9001, "JSON 형식이 잘못되었습니다."),
     INVALID_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, 9002, "유효하지 않은 값이 발견되었습니다."),


### PR DESCRIPTION
## Task Description
- 재난콘텐츠 목록 조회 api 구현 ( https://api.daepiro.com/swagger-ui/index.html#/Disaster%20Content%20API/getDisasterContents )
- 재난콘텐츠 검색 api 구현( https://api.daepiro.com/swagger-ui/index.html#/Disaster%20Content%20API/searchDisasterContents )

## Notes
- 재난콘텐츠 목록 조회 인기순 조회는 추후 News 스키마가 Article 스키마와 병합된후 좋아요수와 조회수를 이용해 작성할 예정입니다. 현재는 인기순으로 요청해도 최신순으로 응답되도록 임시로 만들어 놨습니다.
- 이번 작업에서 사용한 News 스키마는 Article 스키마가 완성되기 전에 임시로 사용하는 스키마 입니다.