### PR TITLE
[feat/29] 주변 대피소 api 구현

### DIFF
--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -31,7 +31,8 @@ class SwaggerConfig {
                 "/v1/users/**",
                 "/v1/datacollector/**",
                 "/v1/home/**",
-                "/v1/disastercontents/**"
+                "/v1/disastercontents/**",
+                "/v1/shelters/**",
             )
             .build()
     }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
@@ -1,0 +1,29 @@
+package com.numberone.daepiro.domain.shelter.api
+
+import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Shelter API", description = "대피소 관련 API")
+@RequestMapping("/v1/shelters")
+interface ShelterApiV1 {
+    @GetMapping("/{type}")
+    @Operation(
+        summary = "주변 대피소 목록 조회", description = """
+        사용자의 주변 대피소 목록을 조회합니다.
+        쿼리 파라미터로 대피소 유형을 지정해주세요. (temperature: 쉼터, earthquake: 지진, tsunami: 지진해일, civil: 민방위)
+        이 api 호출 이전에 gps 정보 업데이트 api를 통해 사용자의 위치 정보를 업데이트 해주세요.
+        """
+    )
+    fun getNearbyShelters(
+        @Schema(
+            description = "대피소 유형 (temperature | earthquake | tsunami | civil)",
+            example = "temperature"
+        ) @PathVariable type: String,
+    ): ApiResult<GetNearbySheltersResponse>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 interface ShelterApiV1 {
     @GetMapping("/{type}")
     @Operation(
-        summary = "주변 대피소 목록 조회", description = """
+        summary = "주변 대피소 목록 조회",
+        description = """
         사용자의 주변 대피소 목록을 조회합니다.
         쿼리 파라미터로 대피소 유형을 지정해주세요. (temperature: 쉼터, earthquake: 지진, tsunami: 지진해일, civil: 민방위)
         이 api 호출 이전에 gps 정보 업데이트 api를 통해 사용자의 위치 정보를 업데이트 해주세요.

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
@@ -1,0 +1,19 @@
+package com.numberone.daepiro.domain.shelter.controller
+
+import com.numberone.daepiro.domain.shelter.api.ShelterApiV1
+import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.domain.shelter.service.ShelterService
+import com.numberone.daepiro.global.dto.ApiResult
+import com.numberone.daepiro.global.utils.SecurityContextUtils
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ShelterController(
+    private val shelterService: ShelterService
+) : ShelterApiV1 {
+    override fun getNearbyShelters(type: String): ApiResult<GetNearbySheltersResponse> {
+        val userId = SecurityContextUtils.getUserId()
+        return shelterService.getNearbyShelters(userId, type)
+    }
+
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
@@ -15,5 +15,4 @@ class ShelterController(
         val userId = SecurityContextUtils.getUserId()
         return shelterService.getNearbyShelters(userId, type)
     }
-
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/GetNearbySheltersResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/GetNearbySheltersResponse.kt
@@ -1,0 +1,36 @@
+package com.numberone.daepiro.domain.shelter.dto.response
+
+import com.numberone.daepiro.domain.shelter.entity.Shelter
+import com.numberone.daepiro.domain.shelter.utils.DistanceUtils
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GetNearbySheltersResponse(
+    @Schema(description = "현재 위치", example = "서울특별시 강남구 역삼동 123-45")
+    val myLocation: String,
+
+    val shelters: List<ShelterResponse>
+) {
+    companion object {
+        fun of(
+            myLocation: String,
+            shelters: List<Shelter>,
+            longitude: Double,
+            latitude: Double
+        ): GetNearbySheltersResponse {
+            return GetNearbySheltersResponse(
+                myLocation,
+                shelters.map {
+                    ShelterResponse.of(
+                        it,
+                        DistanceUtils.calculateDistance(
+                            longitude,
+                            latitude,
+                            it.longitude,
+                            it.latitude
+                        )
+                    )
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/ShelterResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/ShelterResponse.kt
@@ -1,0 +1,33 @@
+package com.numberone.daepiro.domain.shelter.dto.response
+
+import com.numberone.daepiro.domain.shelter.entity.Shelter
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ShelterResponse(
+    @Schema(description = "대피소 이름", example = "EG스위트빌경로당(금호2동)")
+    val name: String,
+
+    @Schema(description = "대피소까지의 거리", example = "250")
+    val distance: Long,
+
+    @Schema(description = "대피소 주소", example = "광주광역시 서구 화개중앙로87번길 16-1 (금호동, EG스위트밸리)")
+    val address: String,
+
+    @Schema(description = "대피소 경도", example = "126.8509506")
+    val longitude: Double,
+
+    @Schema(description = "대피소 위도", example = "35.1277754")
+    val latitude: Double
+) {
+    companion object {
+        fun of(shelter: Shelter, distance: Long): ShelterResponse {
+            return ShelterResponse(
+                name = shelter.name,
+                distance = distance,
+                address = shelter.address,
+                longitude = shelter.longitude,
+                latitude = shelter.latitude
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
@@ -1,0 +1,39 @@
+package com.numberone.daepiro.domain.shelter.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "`shelter`")
+class Shelter(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    val name: String,
+
+    val address: String,
+
+    val longitude: Double,
+
+    val latitude: Double,
+
+    @Enumerated(EnumType.STRING)
+    val type: ShelterType
+) {
+}
+
+enum class ShelterType(
+    val korean: String
+) {
+    TEMPERATURE("쉼터"),
+    EARTHQUAKE("지진옥외"),
+    TSUNAMI("지진해일"),
+    CIVIL("민방위")
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
@@ -27,8 +27,7 @@ class Shelter(
 
     @Enumerated(EnumType.STRING)
     val type: ShelterType
-) {
-}
+)
 
 enum class ShelterType(
     val word: String

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.shelter.entity
 
-import jakarta.persistence.Column
+import com.numberone.daepiro.global.exception.CustomErrorContext
+import com.numberone.daepiro.global.exception.CustomException
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -30,10 +31,17 @@ class Shelter(
 }
 
 enum class ShelterType(
-    val korean: String
+    val word: String
 ) {
-    TEMPERATURE("쉼터"),
-    EARTHQUAKE("지진옥외"),
-    TSUNAMI("지진해일"),
-    CIVIL("민방위")
+    TEMPERATURE("temperature"),
+    EARTHQUAKE("earthquake"),
+    TSUNAMI("tsunami"),
+    CIVIL("civil");
+
+    companion object {
+        fun word2code(korean: String): ShelterType {
+            return entries.find { it.word == korean }
+                ?: throw CustomException(CustomErrorContext.NOT_FOUND_SHELTER_TYPE)
+        }
+    }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
@@ -13,7 +13,8 @@ interface ShelterRepository : JpaRepository<Shelter, Long> {
             "ORDER BY (6371 * ACOS(COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
             "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
             "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude)))) " +
-            "LIMIT 10", nativeQuery = true
+            "LIMIT 10",
+        nativeQuery = true
     )
     fun findTop10ClosestShelters(
         @Param("longitude") longitude: Double,

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
@@ -9,13 +9,15 @@ interface ShelterRepository : JpaRepository<Shelter, Long> {
     @Query(
         value = "SELECT id, name, latitude, longitude, address, type " +
             "FROM shelter " +
+            "WHERE type = :type " +
             "ORDER BY (6371 * ACOS(COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
             "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
-            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))))" +
+            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude)))) " +
             "LIMIT 10", nativeQuery = true
     )
     fun findTop10ClosestShelters(
         @Param("longitude") longitude: Double,
-        @Param("latitude") latitude: Double
+        @Param("latitude") latitude: Double,
+        @Param("type") type: String
     ): List<Shelter>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
@@ -1,0 +1,21 @@
+package com.numberone.daepiro.domain.shelter.repository
+
+import com.numberone.daepiro.domain.shelter.entity.Shelter
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ShelterRepository : JpaRepository<Shelter, Long> {
+    @Query(
+        value = "SELECT id, name, latitude, longitude, address, type " +
+            "FROM shelter " +
+            "ORDER BY (6371 * ACOS(COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
+            "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
+            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))))" +
+            "LIMIT 10", nativeQuery = true
+    )
+    fun findTop10ClosestShelters(
+        @Param("longitude") longitude: Double,
+        @Param("latitude") latitude: Double
+    ): List<Shelter>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
@@ -1,0 +1,38 @@
+package com.numberone.daepiro.domain.shelter.service
+
+import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.domain.shelter.repository.ShelterRepository
+import com.numberone.daepiro.domain.user.repository.UserRepository
+import com.numberone.daepiro.domain.user.repository.findByIdOrThrow
+import com.numberone.daepiro.global.dto.ApiResult
+import com.numberone.daepiro.global.exception.CustomErrorContext
+import com.numberone.daepiro.global.exception.CustomException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ShelterService(
+    private val shelterRepository: ShelterRepository,
+    private val userRepository: UserRepository,
+) {
+    fun getNearbyShelters(userId: Long, type: String): ApiResult<GetNearbySheltersResponse> {
+        val user = userRepository.findByIdOrThrow(userId)
+        if (user.address == null || user.longitude == null || user.latitude == null) {
+            throw CustomException(CustomErrorContext.NOT_FOUND_USER_LOCATION)
+        }
+        val address = user.address!!
+        val longitude = user.longitude!!
+        val latitude = user.latitude!!
+
+        val shelters = shelterRepository.findTop10ClosestShelters(longitude, latitude)
+        return ApiResult.ok(
+            GetNearbySheltersResponse.of(
+                address.toAddress(),
+                shelters,
+                longitude,
+                latitude
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.shelter.service
 
 import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.domain.shelter.entity.ShelterType
 import com.numberone.daepiro.domain.shelter.repository.ShelterRepository
 import com.numberone.daepiro.domain.user.repository.UserRepository
 import com.numberone.daepiro.domain.user.repository.findByIdOrThrow
@@ -25,7 +26,7 @@ class ShelterService(
         val longitude = user.longitude!!
         val latitude = user.latitude!!
 
-        val shelters = shelterRepository.findTop10ClosestShelters(longitude, latitude)
+        val shelters = shelterRepository.findTop10ClosestShelters(longitude, latitude, ShelterType.word2code(type).name)
         return ApiResult.ok(
             GetNearbySheltersResponse.of(
                 address.toAddress(),

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
@@ -5,11 +5,13 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 object DistanceUtils {
-    fun calculateDistance(lon1: Double, lat1: Double, lon2: Double,lat2: Double): Long {
-        return (6371 * acos(
-            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
-                cos(Math.toRadians(lon2) - Math.toRadians(lon1)) +
-                sin(Math.toRadians(lat1)) * sin(Math.toRadians(lat2))
-        )).toLong()
+    fun calculateDistance(lon1: Double, lat1: Double, lon2: Double, lat2: Double): Long {
+        return (
+            6371 * acos(
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                    cos(Math.toRadians(lon2) - Math.toRadians(lon1)) +
+                    sin(Math.toRadians(lat1)) * sin(Math.toRadians(lat2))
+            )
+            ).toLong()
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
@@ -1,0 +1,15 @@
+package com.numberone.daepiro.domain.shelter.utils
+
+import kotlin.math.acos
+import kotlin.math.cos
+import kotlin.math.sin
+
+object DistanceUtils {
+    fun calculateDistance(lon1: Double, lat1: Double, lon2: Double,lat2: Double): Long {
+        return (6371 * acos(
+            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                cos(Math.toRadians(lon2) - Math.toRadians(lon1)) +
+                sin(Math.toRadians(lat1)) * sin(Math.toRadians(lat2))
+        )).toLong()
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
@@ -43,6 +43,10 @@ class UserEntity(
     @JoinColumn(name = "address_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var address: Address? = null,
 
+    var longitude: Double? = null,
+
+    var latitude: Double? = null,
+
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
     val userAddresses: List<UserAddress> = emptyList(),
 
@@ -82,7 +86,13 @@ class UserEntity(
         isCompletedOnboarding = true
     }
 
-    fun updateLocation(location: Address) {
+    fun updateLocation(
+        location: Address,
+        longitude: Double,
+        latitude: Double
+    ) {
         this.address = location
+        this.longitude = longitude
+        this.latitude = latitude
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
@@ -112,7 +112,7 @@ class UserService(
         val address = getAddressFromGPS(request.longitude, request.latitude)
         val user = userRepository.findByIdOrThrow(userId)
 
-        user.updateLocation(address)
+        user.updateLocation(address, request.longitude, request.latitude)
         return ApiResult.ok()
     }
 

--- a/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
@@ -31,6 +31,9 @@ enum class CustomErrorContext(
     // 24xx: 재난콘텐츠 관련 오류
     INVALID_DISASTER_CONTENT_SORT_TYPE(HttpStatus.BAD_REQUEST, 2400, "재난 콘텐츠 정렬 형식이 잘못되었습니다."),
 
+    // 25xx: 대피소 관련 오류
+    NOT_FOUND_SHELTER_TYPE(HttpStatus.NOT_FOUND, 2500, "대피소 유형을 찾을 수 없습니다."),
+
     // 99xx: 공통 오류
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, 9001, "JSON 형식이 잘못되었습니다."),
     INVALID_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, 9002, "유효하지 않은 값이 발견되었습니다."),

--- a/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
@@ -18,6 +18,7 @@ enum class CustomErrorContext(
 
     // 21xx: 사용자 관련 오류
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2100, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_USER_LOCATION(HttpStatus.BAD_REQUEST, 2101, "사용자의 위치 정보를 찾을 수 없습니다."),
 
     // 22xx: 재난 관련 오류
     NOT_FOUND_DISASTER_TYPE(HttpStatus.NOT_FOUND, 2200, "재난 유형을 찾을 수 없습니다."),


### PR DESCRIPTION
## Swagger
https://api.daepiro.com/swagger-ui/index.html#/Shelter%20API/getNearbyShelters

## Task Description
- 쉼터, 지진해일, 지진옥외, 민방위 대피소 데이터를 서버 DB 하나의 스키마에 저장
- 사용자의 gps 위치에 따른 대피소 정보 api 개발

## Notes
- 대피소를 조회하는 쿼리가 계속 풀스캔을 타기 때문에 출시 이후에 성능 이슈가 생길수 있는 포인트라고 생각해요. 더 효율적인 방안이 많을것 같지만 일단 기능 구현만을 위해서 개발하였습니다.
- 데이터베이스의 Shelter 테이블에 공공 api에서 끌고온 대피소 정보를 모두 저장해두었습니다.