### PR TITLE
[feat/31] 커뮤니티 재난상황 fake api 개발

### DIFF
--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -33,6 +33,7 @@ class SwaggerConfig {
                 "/v1/home/**",
                 "/v1/disastercontents/**",
                 "/v1/shelters/**",
+                "/v1/disastersituations/**"
             )
             .build()
     }

--- a/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/numberone/daepiro/config/SwaggerConfig.kt
@@ -31,7 +31,8 @@ class SwaggerConfig {
                 "/v1/users/**",
                 "/v1/datacollector/**",
                 "/v1/home/**",
-                "/v1/disastercontents/**"
+                "/v1/disastercontents/**",
+                "/v1/shelters/**",
             )
             .build()
     }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
@@ -11,7 +11,6 @@ import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -20,40 +19,52 @@ import org.springframework.web.bind.annotation.RequestMapping
 @RequestMapping("/v1/disastersituations")
 interface DisasterSituationApiV1 {
     @GetMapping
-    @Operation(summary = "(fake api) 재난상황 글 목록 조회", description = """
+    @Operation(
+        summary = "(fake api) 재난상황 글 목록 조회",
+        description = """
         재난상황 글 목록을 조회합니다.
         프론트에서 수신/전체 필터링은 반환된 리스트 안에 각 데이터의 isReceived 필드를 이용하여 구분하도록 구현하였습니다.
         (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
-    """)
+    """
+    )
     fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>>
 
     @GetMapping("/comments/{situationId}")
-    @Operation(summary = "(fake api) 댓글 목록 조회", description = """
+    @Operation(
+        summary = "(fake api) 댓글 목록 조회",
+        description = """
         특정 재난상황 글의 댓글 목록을 조회합니다.
         댓글의 대댓글은 childComments 필드를 이용하여 구현하였습니다.
         (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
-    """)
+    """
+    )
     fun getComments(
         @Schema(description = "재난상황 글 id", example = "1032") @PathVariable situationId: Long
     ): ApiResult<List<SituationCommentResponse>>
 
     @PutMapping("/comments/{commentId}")
-    @Operation(summary = "(fake api) 댓글 수정", description = """
+    @Operation(
+        summary = "(fake api) 댓글 수정",
+        description = """
         댓글을 수정합니다.
         댓글 작성자만 수정할 수 있습니다.
         (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
-    """)
+    """
+    )
     fun editComment(
         @Schema(description = "댓글 id", example = "325") @PathVariable commentId: Long,
         @RequestBody @Valid request: EditCommentRequest
     ): ApiResult<Unit>
 
     @DeleteMapping("/comments/{commentId}")
-    @Operation(summary = "(fake api) 댓글 삭제", description = """
+    @Operation(
+        summary = "(fake api) 댓글 삭제",
+        description = """
         댓글을 삭제합니다.
         댓글 작성자만 삭제할 수 있습니다.
         (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
-    """)
+    """
+    )
     fun deleteComment(
         @Schema(description = "댓글 id", example = "325") @PathVariable commentId: Long
     ): ApiResult<Unit>

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
@@ -21,7 +21,7 @@ interface DisasterSituationApiV1 {
     """)
     fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>>
 
-    @GetMapping("comments/{situationId}")
+    @GetMapping("/comments/{situationId}")
     @Operation(summary = "(fake api) 댓글 목록 조회", description = """
         특정 재난상황 글의 댓글 목록을 조회합니다.
         댓글의 대댓글은 childComments 필드를 이용하여 구현하였습니다.
@@ -30,4 +30,6 @@ interface DisasterSituationApiV1 {
     fun getComments(
         @Schema(description = "재난상황 글 id", example = "1032") @PathVariable situationId: Long
     ): ApiResult<List<SituationCommentResponse>>
+
+
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
@@ -1,0 +1,19 @@
+package com.numberone.daepiro.domain.disasterSituation.api
+
+import com.numberone.daepiro.domain.disasterSituation.dto.response.DisasterSituationResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Disaster Situation API", description = "재난 상황용 API")
+@RequestMapping("/v1/disastersituations")
+interface DisasterSituationApiV1 {
+    @GetMapping
+    @Operation(summary = "재난상황 글 목록 조회", description = """
+        재난상황 글 목록을 조회합니다.
+        프론트에서 수신/전체 필터링은 반환된 리스트 안에 각 데이터의 isReceived 필드를 이용하여 구분하도록 구현하였습니다.
+    """)
+    fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
@@ -1,13 +1,19 @@
 package com.numberone.daepiro.domain.disasterSituation.api
 
+import com.numberone.daepiro.domain.disasterSituation.dto.request.EditCommentRequest
 import com.numberone.daepiro.domain.disasterSituation.dto.response.DisasterSituationResponse
 import com.numberone.daepiro.domain.disasterSituation.dto.response.SituationCommentResponse
 import com.numberone.daepiro.global.dto.ApiResult
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 
 @Tag(name = "Disaster Situation API", description = "재난 상황용 API")
@@ -31,5 +37,24 @@ interface DisasterSituationApiV1 {
         @Schema(description = "재난상황 글 id", example = "1032") @PathVariable situationId: Long
     ): ApiResult<List<SituationCommentResponse>>
 
+    @PutMapping("/comments/{commentId}")
+    @Operation(summary = "(fake api) 댓글 수정", description = """
+        댓글을 수정합니다.
+        댓글 작성자만 수정할 수 있습니다.
+        (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
+    """)
+    fun editComment(
+        @Schema(description = "댓글 id", example = "325") @PathVariable commentId: Long,
+        @RequestBody @Valid request: EditCommentRequest
+    ): ApiResult<Unit>
 
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(summary = "(fake api) 댓글 삭제", description = """
+        댓글을 삭제합니다.
+        댓글 작성자만 삭제할 수 있습니다.
+        (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
+    """)
+    fun deleteComment(
+        @Schema(description = "댓글 id", example = "325") @PathVariable commentId: Long
+    ): ApiResult<Unit>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/api/DisasterSituationApiV1.kt
@@ -1,19 +1,33 @@
 package com.numberone.daepiro.domain.disasterSituation.api
 
 import com.numberone.daepiro.domain.disasterSituation.dto.response.DisasterSituationResponse
+import com.numberone.daepiro.domain.disasterSituation.dto.response.SituationCommentResponse
 import com.numberone.daepiro.global.dto.ApiResult
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 
 @Tag(name = "Disaster Situation API", description = "재난 상황용 API")
 @RequestMapping("/v1/disastersituations")
 interface DisasterSituationApiV1 {
     @GetMapping
-    @Operation(summary = "재난상황 글 목록 조회", description = """
+    @Operation(summary = "(fake api) 재난상황 글 목록 조회", description = """
         재난상황 글 목록을 조회합니다.
         프론트에서 수신/전체 필터링은 반환된 리스트 안에 각 데이터의 isReceived 필드를 이용하여 구분하도록 구현하였습니다.
+        (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
     """)
     fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>>
+
+    @GetMapping("comments/{situationId}")
+    @Operation(summary = "(fake api) 댓글 목록 조회", description = """
+        특정 재난상황 글의 댓글 목록을 조회합니다.
+        댓글의 대댓글은 childComments 필드를 이용하여 구현하였습니다.
+        (fake api는 미구현 기능에 대해서 프론트 테스트를 위해 어떤 요청값이든 고정된 응답값만 반환하도록 설계되어 있습니다.)
+    """)
+    fun getComments(
+        @Schema(description = "재난상황 글 id", example = "1032") @PathVariable situationId: Long
+    ): ApiResult<List<SituationCommentResponse>>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.disasterSituation.controller
 
 import com.numberone.daepiro.domain.disasterSituation.api.DisasterSituationApiV1
+import com.numberone.daepiro.domain.disasterSituation.dto.request.EditCommentRequest
 import com.numberone.daepiro.domain.disasterSituation.dto.response.DisasterSituationResponse
 import com.numberone.daepiro.domain.disasterSituation.dto.response.SituationCommentResponse
 import com.numberone.daepiro.global.dto.ApiResult
@@ -124,5 +125,13 @@ class DisasterSituationController : DisasterSituationApiV1 {
         )
 
         return ApiResult.ok(comments)
+    }
+
+    override fun editComment(commentId: Long, request: EditCommentRequest): ApiResult<Unit> {
+        return ApiResult.ok()
+    }
+
+    override fun deleteComment(commentId: Long): ApiResult<Unit> {
+        return ApiResult.ok()
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
@@ -18,6 +18,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                 time = LocalDateTime.of(2024, 10, 23, 19, 53),
                 content = "이런 상황에서는 이렇게 대처하는 것이 좋아요!",
                 likeCount = 3,
+                isMine = true,
                 childComments = listOf(
                     SituationCommentResponse.ofFake(
                         id = 2,
@@ -25,6 +26,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                         time = LocalDateTime.of(2024, 10, 23, 19, 53),
                         content = "싫은데요?",
                         likeCount = 1,
+                        isMine = false,
                         childComments = emptyList()
                     ),
                     SituationCommentResponse.ofFake(
@@ -33,6 +35,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                         time = LocalDateTime.of(2024, 10, 23, 19, 53),
                         content = "절대 안해야지",
                         likeCount = 2,
+                        isMine = false,
                         childComments = emptyList()
                     )
                 )
@@ -78,6 +81,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                         time = LocalDateTime.of(2024, 10, 23, 19, 53),
                         content = "지진이라니",
                         likeCount = 3,
+                        isMine = false,
                         childComments = emptyList()
                     )
                 )
@@ -95,6 +99,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                 time = LocalDateTime.of(2024, 10, 23, 19, 53),
                 content = "이런 상황에서는 이렇게 대처하는 것이 좋아요!",
                 likeCount = 3,
+                isMine = true,
                 childComments = listOf(
                     SituationCommentResponse.ofFake(
                         id = 2,
@@ -102,6 +107,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                         time = LocalDateTime.of(2024, 10, 23, 19, 53),
                         content = "싫은데요?",
                         likeCount = 1,
+                        isMine = false,
                         childComments = emptyList()
                     ),
                     SituationCommentResponse.ofFake(
@@ -110,6 +116,7 @@ class DisasterSituationController : DisasterSituationApiV1 {
                         time = LocalDateTime.of(2024, 10, 23, 19, 53),
                         content = "절대 안해야지",
                         likeCount = 2,
+                        isMine = false,
                         childComments = emptyList()
                     )
                 )

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 
 @RestController
-class DisasterSituationController: DisasterSituationApiV1 {
+class DisasterSituationController : DisasterSituationApiV1 {
     //todo fake api용 코드입니다. 추후 삭제 필요
     override fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>> {
         val comments = listOf(
@@ -85,5 +85,37 @@ class DisasterSituationController: DisasterSituationApiV1 {
         )
 
         return ApiResult.ok(disasterSituations)
+    }
+
+    override fun getComments(situationId: Long): ApiResult<List<SituationCommentResponse>> {
+        val comments = listOf(
+            SituationCommentResponse.ofFake(
+                id = 1,
+                name = "김연지",
+                time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                content = "이런 상황에서는 이렇게 대처하는 것이 좋아요!",
+                likeCount = 3,
+                childComments = listOf(
+                    SituationCommentResponse.ofFake(
+                        id = 2,
+                        name = "한나영",
+                        time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                        content = "싫은데요?",
+                        likeCount = 1,
+                        childComments = emptyList()
+                    ),
+                    SituationCommentResponse.ofFake(
+                        id = 3,
+                        name = "김서윤",
+                        time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                        content = "절대 안해야지",
+                        likeCount = 2,
+                        childComments = emptyList()
+                    )
+                )
+            )
+        )
+
+        return ApiResult.ok(comments)
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 
 @RestController
 class DisasterSituationController : DisasterSituationApiV1 {
-    //todo fake api용 코드입니다. 추후 삭제 필요
+    // todo fake api용 코드입니다. 추후 삭제 필요
     override fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>> {
         val comments = listOf(
             SituationCommentResponse.ofFake(

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/controller/DisasterSituationController.kt
@@ -1,0 +1,89 @@
+package com.numberone.daepiro.domain.disasterSituation.controller
+
+import com.numberone.daepiro.domain.disasterSituation.api.DisasterSituationApiV1
+import com.numberone.daepiro.domain.disasterSituation.dto.response.DisasterSituationResponse
+import com.numberone.daepiro.domain.disasterSituation.dto.response.SituationCommentResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+class DisasterSituationController: DisasterSituationApiV1 {
+    //todo fake api용 코드입니다. 추후 삭제 필요
+    override fun getDisasterSituations(): ApiResult<List<DisasterSituationResponse>> {
+        val comments = listOf(
+            SituationCommentResponse.ofFake(
+                id = 1,
+                name = "김연지",
+                time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                content = "이런 상황에서는 이렇게 대처하는 것이 좋아요!",
+                likeCount = 3,
+                childComments = listOf(
+                    SituationCommentResponse.ofFake(
+                        id = 2,
+                        name = "한나영",
+                        time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                        content = "싫은데요?",
+                        likeCount = 1,
+                        childComments = emptyList()
+                    ),
+                    SituationCommentResponse.ofFake(
+                        id = 3,
+                        name = "김서윤",
+                        time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                        content = "절대 안해야지",
+                        likeCount = 2,
+                        childComments = emptyList()
+                    )
+                )
+            )
+        )
+
+        val disasterSituations = listOf(
+            DisasterSituationResponse.ofFake(
+                id = 1032,
+                type = "호우",
+                title = "서울특별시 성북구 쌍문동 호우 발생",
+                content = "금일 10.23. 19:39경 소촌동 855 화재 발생, 인근주민은 안전 유의 및 차량우회바랍니다. 960-8222",
+                location = "서울특별시 성북구",
+                time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                commentCount = 1,
+                isReceived = true,
+                comments = comments
+            ),
+            DisasterSituationResponse.ofFake(
+                id = 1033,
+                type = "화재",
+                title = "서울특별시 성북구 쌍문동 화재 발생",
+                content = "금일 10.23. 19:39경 소촌동 855 화재 발생, 인근주민은 안전 유의 및 차량우회바랍니다. 960-8222",
+                location = "서울특별시 성북구",
+                time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                commentCount = 1,
+                isReceived = false,
+                comments = emptyList()
+            ),
+            DisasterSituationResponse.ofFake(
+                id = 1034,
+                type = "지진",
+                title = "서울특별시 성북구 쌍문동 지진 발생",
+                content = "금일 10.23. 19:39경 소촌동 855 지진 발생, 인근주민은 안전 유의 및 차량우회바랍니다. 960-8222",
+                location = "서울특별시 성북구",
+                time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                commentCount = 1,
+                isReceived = false,
+                comments = listOf(
+                    SituationCommentResponse.ofFake(
+                        id = 5,
+                        name = "오종석",
+                        time = LocalDateTime.of(2024, 10, 23, 19, 53),
+                        content = "지진이라니",
+                        likeCount = 3,
+                        childComments = emptyList()
+                    )
+                )
+            )
+        )
+
+        return ApiResult.ok(disasterSituations)
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/request/EditCommentRequest.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/request/EditCommentRequest.kt
@@ -1,0 +1,10 @@
+package com.numberone.daepiro.domain.disasterSituation.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+data class EditCommentRequest(
+    @Schema(description = "수정할 댓글 내용", example = "이런 상황에서는 이렇게 대처하는 것이 좋아요!")
+    @NotBlank
+    val content: String
+)

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/DisasterSituationResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/DisasterSituationResponse.kt
@@ -1,0 +1,59 @@
+package com.numberone.daepiro.domain.disasterSituation.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class DisasterSituationResponse(
+    @Schema(description = "재난상황 게시글 id", example = "1032")
+    val id: Long,
+
+    @Schema(description = "재난 종류", example = "호우")
+    val type: String,
+
+    @Schema(description = "제목", example = "서울특별시 성북구 쌍문동 호우 발생")
+    val title: String,
+
+    @Schema(description = "내용", example = "금일 10.23. 19:39경 소촌동 855 화재 발생, 인근주민은 안전 유의 및 차량우회바랍니다. 960-8222")
+    val content: String,
+
+    @Schema(description = "위치", example = "서울특별시 성북구")
+    val location: String,
+
+    @Schema(description = "발생 시간", example = "2024-10-23T19:53:00")
+    val time: LocalDateTime,
+
+    @Schema(description = "댓글 수", example = "3")
+    val commentCount: Long,
+
+    @Schema(description = "수신 여부", example = "true")
+    val isReceived: Boolean,
+
+    val comments: List<SituationCommentResponse>
+) {
+    companion object {
+        //todo fake api용 코드입니다. 추후 삭제 필요
+        fun ofFake(
+            id: Long,
+            type: String,
+            title: String,
+            content: String,
+            location: String,
+            time: LocalDateTime,
+            commentCount: Long,
+            isReceived: Boolean,
+            comments: List<SituationCommentResponse>
+        ): DisasterSituationResponse {
+            return DisasterSituationResponse(
+                id = id,
+                type = type,
+                title = title,
+                content = content,
+                location = location,
+                time = time,
+                commentCount = commentCount,
+                isReceived = isReceived,
+                comments = comments
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/DisasterSituationResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/DisasterSituationResponse.kt
@@ -31,7 +31,7 @@ data class DisasterSituationResponse(
     val comments: List<SituationCommentResponse>
 ) {
     companion object {
-        //todo fake api용 코드입니다. 추후 삭제 필요
+        // todo fake api용 코드입니다. 추후 삭제 필요
         fun ofFake(
             id: Long,
             type: String,

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/SituationCommentResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/SituationCommentResponse.kt
@@ -1,0 +1,44 @@
+package com.numberone.daepiro.domain.disasterSituation.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class SituationCommentResponse(
+    @Schema(description = "댓글 id", example = "325")
+    val id: Long,
+
+    @Schema(description = "작성자 이름", example = "김연지")
+    val name: String,
+
+    @Schema(description = "작성 시간", example = "2024-10-23T19:53:00")
+    val time: LocalDateTime,
+
+    @Schema(description = "댓글 내용", example = "이런 상황에서는 이렇게 대처하는 것이 좋아요!")
+    val content: String,
+
+    @Schema(description = "좋아요 수", example = "3")
+    val likeCount: Long,
+
+    val childComments: List<SituationCommentResponse>
+) {
+    companion object {
+        //todo fake api용 코드입니다. 추후 삭제 필요
+        fun ofFake(
+            id: Long,
+            name: String,
+            time: LocalDateTime,
+            content: String,
+            likeCount: Long,
+            childComments: List<SituationCommentResponse>
+        ): SituationCommentResponse {
+            return SituationCommentResponse(
+                id = id,
+                name = name,
+                time = time,
+                content = content,
+                likeCount = likeCount,
+                childComments = childComments
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/SituationCommentResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/SituationCommentResponse.kt
@@ -19,6 +19,9 @@ data class SituationCommentResponse(
     @Schema(description = "좋아요 수", example = "3")
     val likeCount: Long,
 
+    @Schema(description = "내 댓글 여부", example = "true")
+    val isMine:Boolean,
+
     val childComments: List<SituationCommentResponse>
 ) {
     companion object {
@@ -29,6 +32,7 @@ data class SituationCommentResponse(
             time: LocalDateTime,
             content: String,
             likeCount: Long,
+            isMine: Boolean,
             childComments: List<SituationCommentResponse>
         ): SituationCommentResponse {
             return SituationCommentResponse(
@@ -37,6 +41,7 @@ data class SituationCommentResponse(
                 time = time,
                 content = content,
                 likeCount = likeCount,
+                isMine = isMine,
                 childComments = childComments
             )
         }

--- a/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/SituationCommentResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/disasterSituation/dto/response/SituationCommentResponse.kt
@@ -20,12 +20,12 @@ data class SituationCommentResponse(
     val likeCount: Long,
 
     @Schema(description = "내 댓글 여부", example = "true")
-    val isMine:Boolean,
+    val isMine: Boolean,
 
     val childComments: List<SituationCommentResponse>
 ) {
     companion object {
-        //todo fake api용 코드입니다. 추후 삭제 필요
+        // todo fake api용 코드입니다. 추후 삭제 필요
         fun ofFake(
             id: Long,
             name: String,

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
@@ -1,0 +1,29 @@
+package com.numberone.daepiro.domain.shelter.api
+
+import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.global.dto.ApiResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Shelter API", description = "대피소 관련 API")
+@RequestMapping("/v1/shelters")
+interface ShelterApiV1 {
+    @GetMapping("/{type}")
+    @Operation(
+        summary = "주변 대피소 목록 조회", description = """
+        사용자의 주변 대피소 목록을 조회합니다.
+        쿼리 파라미터로 대피소 유형을 지정해주세요. (temperature: 쉼터, earthquake: 지진, tsunami: 지진해일, civil: 민방위)
+        이 api 호출 이전에 gps 정보 업데이트 api를 통해 사용자의 위치 정보를 업데이트 해주세요.
+        """
+    )
+    fun getNearbyShelters(
+        @Schema(
+            description = "대피소 유형 (temperature | earthquake | tsunami | civil)",
+            example = "temperature"
+        ) @PathVariable type: String,
+    ): ApiResult<GetNearbySheltersResponse>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/api/ShelterApiV1.kt
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 interface ShelterApiV1 {
     @GetMapping("/{type}")
     @Operation(
-        summary = "주변 대피소 목록 조회", description = """
+        summary = "주변 대피소 목록 조회",
+        description = """
         사용자의 주변 대피소 목록을 조회합니다.
         쿼리 파라미터로 대피소 유형을 지정해주세요. (temperature: 쉼터, earthquake: 지진, tsunami: 지진해일, civil: 민방위)
         이 api 호출 이전에 gps 정보 업데이트 api를 통해 사용자의 위치 정보를 업데이트 해주세요.

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
@@ -1,0 +1,19 @@
+package com.numberone.daepiro.domain.shelter.controller
+
+import com.numberone.daepiro.domain.shelter.api.ShelterApiV1
+import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.domain.shelter.service.ShelterService
+import com.numberone.daepiro.global.dto.ApiResult
+import com.numberone.daepiro.global.utils.SecurityContextUtils
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ShelterController(
+    private val shelterService: ShelterService
+) : ShelterApiV1 {
+    override fun getNearbyShelters(type: String): ApiResult<GetNearbySheltersResponse> {
+        val userId = SecurityContextUtils.getUserId()
+        return shelterService.getNearbyShelters(userId, type)
+    }
+
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/controller/ShelterController.kt
@@ -15,5 +15,4 @@ class ShelterController(
         val userId = SecurityContextUtils.getUserId()
         return shelterService.getNearbyShelters(userId, type)
     }
-
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/GetNearbySheltersResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/GetNearbySheltersResponse.kt
@@ -1,0 +1,36 @@
+package com.numberone.daepiro.domain.shelter.dto.response
+
+import com.numberone.daepiro.domain.shelter.entity.Shelter
+import com.numberone.daepiro.domain.shelter.utils.DistanceUtils
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GetNearbySheltersResponse(
+    @Schema(description = "현재 위치", example = "서울특별시 강남구 역삼동 123-45")
+    val myLocation: String,
+
+    val shelters: List<ShelterResponse>
+) {
+    companion object {
+        fun of(
+            myLocation: String,
+            shelters: List<Shelter>,
+            longitude: Double,
+            latitude: Double
+        ): GetNearbySheltersResponse {
+            return GetNearbySheltersResponse(
+                myLocation,
+                shelters.map {
+                    ShelterResponse.of(
+                        it,
+                        DistanceUtils.calculateDistance(
+                            longitude,
+                            latitude,
+                            it.longitude,
+                            it.latitude
+                        )
+                    )
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/ShelterResponse.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/dto/response/ShelterResponse.kt
@@ -1,0 +1,33 @@
+package com.numberone.daepiro.domain.shelter.dto.response
+
+import com.numberone.daepiro.domain.shelter.entity.Shelter
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ShelterResponse(
+    @Schema(description = "대피소 이름", example = "EG스위트빌경로당(금호2동)")
+    val name: String,
+
+    @Schema(description = "대피소까지의 거리", example = "250")
+    val distance: Long,
+
+    @Schema(description = "대피소 주소", example = "광주광역시 서구 화개중앙로87번길 16-1 (금호동, EG스위트밸리)")
+    val address: String,
+
+    @Schema(description = "대피소 경도", example = "126.8509506")
+    val longitude: Double,
+
+    @Schema(description = "대피소 위도", example = "35.1277754")
+    val latitude: Double
+) {
+    companion object {
+        fun of(shelter: Shelter, distance: Long): ShelterResponse {
+            return ShelterResponse(
+                name = shelter.name,
+                distance = distance,
+                address = shelter.address,
+                longitude = shelter.longitude,
+                latitude = shelter.latitude
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
@@ -1,0 +1,39 @@
+package com.numberone.daepiro.domain.shelter.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "`shelter`")
+class Shelter(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    val name: String,
+
+    val address: String,
+
+    val longitude: Double,
+
+    val latitude: Double,
+
+    @Enumerated(EnumType.STRING)
+    val type: ShelterType
+) {
+}
+
+enum class ShelterType(
+    val korean: String
+) {
+    TEMPERATURE("쉼터"),
+    EARTHQUAKE("지진옥외"),
+    TSUNAMI("지진해일"),
+    CIVIL("민방위")
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
@@ -27,8 +27,7 @@ class Shelter(
 
     @Enumerated(EnumType.STRING)
     val type: ShelterType
-) {
-}
+)
 
 enum class ShelterType(
     val word: String

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/entity/Shelter.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.shelter.entity
 
-import jakarta.persistence.Column
+import com.numberone.daepiro.global.exception.CustomErrorContext
+import com.numberone.daepiro.global.exception.CustomException
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -30,10 +31,17 @@ class Shelter(
 }
 
 enum class ShelterType(
-    val korean: String
+    val word: String
 ) {
-    TEMPERATURE("쉼터"),
-    EARTHQUAKE("지진옥외"),
-    TSUNAMI("지진해일"),
-    CIVIL("민방위")
+    TEMPERATURE("temperature"),
+    EARTHQUAKE("earthquake"),
+    TSUNAMI("tsunami"),
+    CIVIL("civil");
+
+    companion object {
+        fun word2code(korean: String): ShelterType {
+            return entries.find { it.word == korean }
+                ?: throw CustomException(CustomErrorContext.NOT_FOUND_SHELTER_TYPE)
+        }
+    }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
@@ -13,7 +13,8 @@ interface ShelterRepository : JpaRepository<Shelter, Long> {
             "ORDER BY (6371 * ACOS(COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
             "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
             "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude)))) " +
-            "LIMIT 10", nativeQuery = true
+            "LIMIT 10",
+        nativeQuery = true
     )
     fun findTop10ClosestShelters(
         @Param("longitude") longitude: Double,

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
@@ -9,13 +9,15 @@ interface ShelterRepository : JpaRepository<Shelter, Long> {
     @Query(
         value = "SELECT id, name, latitude, longitude, address, type " +
             "FROM shelter " +
+            "WHERE type = :type " +
             "ORDER BY (6371 * ACOS(COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
             "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
-            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))))" +
+            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude)))) " +
             "LIMIT 10", nativeQuery = true
     )
     fun findTop10ClosestShelters(
         @Param("longitude") longitude: Double,
-        @Param("latitude") latitude: Double
+        @Param("latitude") latitude: Double,
+        @Param("type") type: String
     ): List<Shelter>
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/repository/ShelterRepository.kt
@@ -1,0 +1,21 @@
+package com.numberone.daepiro.domain.shelter.repository
+
+import com.numberone.daepiro.domain.shelter.entity.Shelter
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ShelterRepository : JpaRepository<Shelter, Long> {
+    @Query(
+        value = "SELECT id, name, latitude, longitude, address, type " +
+            "FROM shelter " +
+            "ORDER BY (6371 * ACOS(COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
+            "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
+            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))))" +
+            "LIMIT 10", nativeQuery = true
+    )
+    fun findTop10ClosestShelters(
+        @Param("longitude") longitude: Double,
+        @Param("latitude") latitude: Double
+    ): List<Shelter>
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
@@ -1,0 +1,38 @@
+package com.numberone.daepiro.domain.shelter.service
+
+import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.domain.shelter.repository.ShelterRepository
+import com.numberone.daepiro.domain.user.repository.UserRepository
+import com.numberone.daepiro.domain.user.repository.findByIdOrThrow
+import com.numberone.daepiro.global.dto.ApiResult
+import com.numberone.daepiro.global.exception.CustomErrorContext
+import com.numberone.daepiro.global.exception.CustomException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ShelterService(
+    private val shelterRepository: ShelterRepository,
+    private val userRepository: UserRepository,
+) {
+    fun getNearbyShelters(userId: Long, type: String): ApiResult<GetNearbySheltersResponse> {
+        val user = userRepository.findByIdOrThrow(userId)
+        if (user.address == null || user.longitude == null || user.latitude == null) {
+            throw CustomException(CustomErrorContext.NOT_FOUND_USER_LOCATION)
+        }
+        val address = user.address!!
+        val longitude = user.longitude!!
+        val latitude = user.latitude!!
+
+        val shelters = shelterRepository.findTop10ClosestShelters(longitude, latitude)
+        return ApiResult.ok(
+            GetNearbySheltersResponse.of(
+                address.toAddress(),
+                shelters,
+                longitude,
+                latitude
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/service/ShelterService.kt
@@ -1,6 +1,7 @@
 package com.numberone.daepiro.domain.shelter.service
 
 import com.numberone.daepiro.domain.shelter.dto.response.GetNearbySheltersResponse
+import com.numberone.daepiro.domain.shelter.entity.ShelterType
 import com.numberone.daepiro.domain.shelter.repository.ShelterRepository
 import com.numberone.daepiro.domain.user.repository.UserRepository
 import com.numberone.daepiro.domain.user.repository.findByIdOrThrow
@@ -25,7 +26,7 @@ class ShelterService(
         val longitude = user.longitude!!
         val latitude = user.latitude!!
 
-        val shelters = shelterRepository.findTop10ClosestShelters(longitude, latitude)
+        val shelters = shelterRepository.findTop10ClosestShelters(longitude, latitude, ShelterType.word2code(type).name)
         return ApiResult.ok(
             GetNearbySheltersResponse.of(
                 address.toAddress(),

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
@@ -5,11 +5,13 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 object DistanceUtils {
-    fun calculateDistance(lon1: Double, lat1: Double, lon2: Double,lat2: Double): Long {
-        return (6371 * acos(
-            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
-                cos(Math.toRadians(lon2) - Math.toRadians(lon1)) +
-                sin(Math.toRadians(lat1)) * sin(Math.toRadians(lat2))
-        )).toLong()
+    fun calculateDistance(lon1: Double, lat1: Double, lon2: Double, lat2: Double): Long {
+        return (
+            6371 * acos(
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                    cos(Math.toRadians(lon2) - Math.toRadians(lon1)) +
+                    sin(Math.toRadians(lat1)) * sin(Math.toRadians(lat2))
+            )
+            ).toLong()
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/shelter/utils/DistanceUtils.kt
@@ -1,0 +1,15 @@
+package com.numberone.daepiro.domain.shelter.utils
+
+import kotlin.math.acos
+import kotlin.math.cos
+import kotlin.math.sin
+
+object DistanceUtils {
+    fun calculateDistance(lon1: Double, lat1: Double, lon2: Double,lat2: Double): Long {
+        return (6371 * acos(
+            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                cos(Math.toRadians(lon2) - Math.toRadians(lon1)) +
+                sin(Math.toRadians(lat1)) * sin(Math.toRadians(lat2))
+        )).toLong()
+    }
+}

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/entity/UserEntity.kt
@@ -43,6 +43,10 @@ class UserEntity(
     @JoinColumn(name = "address_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     var address: Address? = null,
 
+    var longitude: Double? = null,
+
+    var latitude: Double? = null,
+
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
     val userAddresses: List<UserAddress> = emptyList(),
 
@@ -82,7 +86,13 @@ class UserEntity(
         isCompletedOnboarding = true
     }
 
-    fun updateLocation(location: Address) {
+    fun updateLocation(
+        location: Address,
+        longitude: Double,
+        latitude: Double
+    ) {
         this.address = location
+        this.longitude = longitude
+        this.latitude = latitude
     }
 }

--- a/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/numberone/daepiro/domain/user/service/UserService.kt
@@ -112,7 +112,7 @@ class UserService(
         val address = getAddressFromGPS(request.longitude, request.latitude)
         val user = userRepository.findByIdOrThrow(userId)
 
-        user.updateLocation(address)
+        user.updateLocation(address, request.longitude, request.latitude)
         return ApiResult.ok()
     }
 

--- a/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
@@ -31,6 +31,9 @@ enum class CustomErrorContext(
     // 24xx: 재난콘텐츠 관련 오류
     INVALID_DISASTER_CONTENT_SORT_TYPE(HttpStatus.BAD_REQUEST, 2400, "재난 콘텐츠 정렬 형식이 잘못되었습니다."),
 
+    // 25xx: 대피소 관련 오류
+    NOT_FOUND_SHELTER_TYPE(HttpStatus.NOT_FOUND, 2500, "대피소 유형을 찾을 수 없습니다."),
+
     // 99xx: 공통 오류
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, 9001, "JSON 형식이 잘못되었습니다."),
     INVALID_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, 9002, "유효하지 않은 값이 발견되었습니다."),

--- a/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
+++ b/src/main/kotlin/com/numberone/daepiro/global/exception/CustomErrorContext.kt
@@ -18,6 +18,7 @@ enum class CustomErrorContext(
 
     // 21xx: 사용자 관련 오류
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 2100, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_USER_LOCATION(HttpStatus.BAD_REQUEST, 2101, "사용자의 위치 정보를 찾을 수 없습니다."),
 
     // 22xx: 재난 관련 오류
     NOT_FOUND_DISASTER_TYPE(HttpStatus.NOT_FOUND, 2200, "재난 유형을 찾을 수 없습니다."),


### PR DESCRIPTION
## Swagger
https://api.daepiro.com/swagger-ui/index.html#/Disaster%20Situation%20API/deleteComment
https://api.daepiro.com/swagger-ui/index.html#/Disaster%20Situation%20API/getDisasterSituations
https://api.daepiro.com/swagger-ui/index.html#/Disaster%20Situation%20API/getComments
https://api.daepiro.com/swagger-ui/index.html#/Disaster%20Situation%20API/editComment

## Task Description
- 글 목록 조회 fake api 개발
- 특정 글의 댓글 목록 조회 fake api 개발
- 댓글 수정 fake api 개발
- 댓글 삭제 fake api 개발

## Notes
- 추후 커뮤니티 게시글 스키마가 개발될때까지 프론트에서 커뮤니티 재난상황 api 를 테스트 하기위해 request, response 값만 정의하고 작동하지 않는 fake api를 개발했습니다.
- 현재 pr 리뷰&머지 이전에 feat/29 대피소 api pr을 머지하고 rebase가 필요합니다. 안그럼 리뷰시에 수정된 코드만 볼수가 없더라구요.